### PR TITLE
Splitter features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,18 @@ While service is in operation:
 - if `'POLL_REQUEST'` is false, service will poll Mongo to find a **bulk** job in state `'VALIDATOR.PENDING_QUEUING'`. It will stream the jobs content from Mongo bucket and transform it to records, send the records to the job's `operation.correlationId` AMQP queue and transition the job state to `'IMPORTER.IN_QUEUE'` in Mongo.
 
 ### Environment variables
-| Name           | Mandatory | Description                                                                                                        |
-|----------------|-----------|--------------------------------------------------------------------------------------------------------------------|
-| AMQP_URL       | Yes       | A serialized object of AMQP connection config                                                                      |
-| SRU_URL_BIB    | Yes       | A serialized URL addres to SRU                                                                                     |
-| MONGO_URI      | No        | A serialized URL address of Melinda-rest-api's import queue database. Defaults to `'mongodb://localhost:27017/db'` |
-| OFFLINE_PERIOD | No        | Starting hour and length of offline period. e.g `'11,1'`                                                           |
-| POLL_REQUEST   | No        | A numeric presentation of boolean option to start polling AMQP `'REQUEST'` queue when process is started e.g. `1`  |
-| POLL_WAIT_TIME | No        | A number value presenting time in ms between polling. Defaults to `'1000'`                                         |
-| LOG_LEVEL      | No        | Log information level                                                                                              |
+| Name                 | Mandatory | Description                                                                                                        |
+|----------------------|-----------|--------------------------------------------------------------------------------------------------------------------|
+| AMQP_URL             | Yes       | A serialized object of AMQP connection config                                                                      |
+| SRU_URL_BIB          | Yes       | A serialized URL addres to SRU                                                                                     |
+| MONGO_URI            | No        | A serialized URL address of Melinda-rest-api's import queue database. Defaults to `'mongodb://localhost:27017/db'` |
+| OFFLINE_PERIOD       | No        | Starting hour and length of offline period. e.g `'11,1'`                                                           |
+| POLL_REQUEST         | No        | A numeric presentation of boolean option to start polling AMQP `'REQUEST'` queue when process is started e.g. `1`  |
+| POLL_WAIT_TIME       | No        | A number value presenting time in ms between polling. Defaults to `'1000'`                                         |
+| FAIL_BULK_ON_ERROR   | No        | A numeric presentation of boolean option to fail whole bulk, if reading payload to records errors. Defaults to `true`. |
+| KEEP_SPLITTER_REPORT | No        | When to keep information about bulk payload splitting process in the queueItem. Options `ALL/NONE/ERROR`. Defaults to `ERROR`. | 
+| LOG_LEVEL            | No        | Log information level                                                                                              |
+
 
 ### Mongo
 
@@ -90,7 +93,15 @@ Queue-item schema examle for a bulk job queueItem:
   "handledAmount": 1,
   "rejectedAmount": 1,
   "rejectMessages": ["Cannot overwrite a deleted record. Record 000999999 is written to rej file"]
+  }],
+"splitterReport": [{
+  "recordNumber": 0,
+  "sequenceNumber": 2,
+  "readerErrors": [{
+    "sequenceNumber": 1,
+    "error": "Record is invalid"
   }]
+ }]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.15.4",
 		"@natlibfi/marc-record": "^6.1.2",
-		"@natlibfi/marc-record-serializers": "^8.0.0",
+		"@natlibfi/marc-record-serializers": "^8.0.2",
 		"@natlibfi/melinda-backend-commons": "^2.0.5",
 		"@natlibfi/melinda-commons": "^12.0.0",
 		"@natlibfi/melinda-record-matching": "^1.0.10",

--- a/src/app.js
+++ b/src/app.js
@@ -8,14 +8,14 @@ import toMarcRecordFactory from './interfaces/toMarcRecords';
 const setTimeoutPromise = promisify(setTimeout);
 
 export default async function ({
-  pollRequest, pollWaitTime, amqpUrl, mongoUri, validatorOptions
+  pollRequest, pollWaitTime, amqpUrl, mongoUri, validatorOptions, splitterOptions
 }) {
   const logger = createLogger();
   const collection = pollRequest ? 'prio' : 'bulk';
   const mongoOperator = await mongoFactory(mongoUri, collection);
   const amqpOperator = await amqpFactory(amqpUrl);
   const validator = await validatorFactory(validatorOptions);
-  const toMarcRecords = await toMarcRecordFactory(amqpOperator);
+  const toMarcRecords = await toMarcRecordFactory(amqpOperator, mongoOperator, splitterOptions);
 
   logger.info(`Started Melinda-rest-api-validator: ${pollRequest ? 'PRIORITY' : 'BULK'}`);
 
@@ -192,7 +192,7 @@ export default async function ({
       const {correlationId, operation, contentType} = queueItem;
       logger.silly(`Correlation id: ${correlationId}`);
       // Set Mongo job state
-      await mongoOperator.setState({correlationId, state: QUEUE_ITEM_STATE.VALIDATOR.QUEUEING_IN_PROGRESS});
+      await mongoOperator.setState({correlationId, state: QUEUE_ITEM_STATE.VALIDATOR.QUEUING_IN_PROGRESS});
       try {
         // Get stream from content
         const stream = await mongoOperator.getStream(correlationId);

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,13 @@ export const mongoUri = readEnvironmentVariable('MONGO_URI', {defaultValue: 'mon
 
 const recordType = readEnvironmentVariable('RECORD_TYPE');
 
+export const splitterOptions = {
+  // failBulkError: fail processing whole bulk of records if there's error on serializing a record
+  failBulkOnError: readEnvironmentVariable('FAIL_BULK_ON_ERROR', {defaultValue: 1, format: v => parseBoolean(v)}),
+  // keepSplitterReport: ALL/NONE/ERROR
+  keepSplitterReport: readEnvironmentVariable('KEEP_SPLITTER_REPORT', {defaultValue: 'ERROR'})
+};
+
 export const validatorOptions = {
   formatOptions: generateFormatOptions(),
   sruUrl: readEnvironmentVariable('SRU_URL'),


### PR DESCRIPTION
New features and fixes to **toMarcRecords.js** (splitter)

- ` FAIL_BULK_ON_ERROR`: option to either reject the whole bulk if reader errors or keep handling non-errored records, defaults to `true`

- `KEEP_SPLITTER_REPORT`: option to keep splitterReport that includes reader event count, record count and possible errors in the queueItem.  Cases for keeping the report: `ALL`/`NONE`/`ERROR`, defaults to `ERROR`.

- count reader events (error+data) in `sequenceNumber`
- count reader events (data) in `recordNumber`

- remove possible `operation.correlationId` AMQP queue if the whole job is rejected

- update **readme** to include new options and updated queueItem schema example