### PR TITLE
Add record-type 'autname'

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,7 +9,7 @@ import httpStatus from 'http-status';
 const setTimeoutPromise = promisify(setTimeout);
 
 export default async function ({
-  pollRequest, pollWaitTime, amqpUrl, mongoUri, validatorOptions, splitterOptions
+  pollRequest, pollWaitTime, amqpUrl, mongoUri, validatorOptions, splitterOptions, recordType
 }) {
   const logger = createLogger();
   const collection = pollRequest ? 'prio' : 'bulk';
@@ -19,7 +19,7 @@ export default async function ({
   const validator = await validatorFactory({...validatorOptions, mongoUri});
   const toMarcRecords = await toMarcRecordFactory({amqpOperator, mongoOperator, splitterOptions, mongoUri});
 
-  logger.info(`Started Melinda-rest-api-validator: ${pollRequest ? 'PRIORITY' : 'BULK'}`);
+  logger.info(`Started Melinda-rest-api-validator: ${pollRequest ? 'PRIORITY' : 'BULK'} for ${recordType} records`);
 
   const server = await initCheck();
 

--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,7 @@ export const amqpUrl = readEnvironmentVariable('AMQP_URL', {defaultValue: 'amqp:
 // Mongo variables to bulk
 export const mongoUri = readEnvironmentVariable('MONGO_URI', {defaultValue: 'mongodb://127.0.0.1:27017/db'});
 
-const recordType = readEnvironmentVariable('RECORD_TYPE');
+export const recordType = readEnvironmentVariable('RECORD_TYPE');
 
 export const splitterOptions = {
   // failBulkError: fail processing whole bulk of records if there's error on serializing a record
@@ -30,13 +30,20 @@ export const splitterOptions = {
 const validatorMatchPackages = readEnvironmentVariable('VALIDATOR_MATCH_PACKAGES', {defaultValue: 'IDS,CONTENT'}).split(',');
 
 export const validatorOptions = {
+  recordType,
   formatOptions: generateFormatOptions(),
   sruUrl: readEnvironmentVariable('SRU_URL'),
   matchOptionsList: generateMatchOptionsList()
 };
 
 function generateMatchOptionsList() {
-  return validatorMatchPackages.map(matchPackage => generateMatchOptions(matchPackage));
+  if (recordType === 'bib') {
+    return validatorMatchPackages.map(matchPackage => generateMatchOptions(matchPackage));
+  }
+  if (recordType === 'autname') {
+    return [];
+  }
+  throw new Error(`Unsupported record type ${recordType}`);
 }
 
 function generateMatchOptions(validatorMatchPackage) {
@@ -101,7 +108,11 @@ function generateFormatOptions() {
     return format.BIB_FORMAT_SETTINGS;
   }
 
-  throw new Error('Unsupported record type');
+  if (recordType === 'autname') {
+    return undefined;
+  }
+
+  throw new Error(`Unsupported record type ${recordType}`);
 }
 
 function generateStrategy(validatorMatchPackage) {
@@ -129,7 +140,12 @@ function generateStrategy(validatorMatchPackage) {
     throw new Error('Unsupported match validation package');
   }
 
-  throw new Error('Unsupported record type');
+  if (recordType === 'autname') {
+    return undefined;
+  }
+
+  throw new Error(`Unsupported record type ${recordType}`);
+
 }
 
 
@@ -152,5 +168,9 @@ function generateSearchSpec(validatorMatchPackage) {
     throw new Error('Unsupported match validation package');
   }
 
-  throw new Error('Unsupported record type');
+  if (recordType === 'autname') {
+    return undefined;
+  }
+
+  throw new Error(`Unsupported record type ${recordType}`);
 }

--- a/src/interfaces/validator/merge.js
+++ b/src/interfaces/validator/merge.js
@@ -12,9 +12,15 @@ import {Error as MergeError} from '@natlibfi/melinda-commons';
 const debug = createDebugLogger('@natlibfi/melinda-rest-api-validator:validator:merge');
 const debugData = debug.extend('data');
 
-export default function ({base, source}) {
+export default function ({base, source, recordType}) {
   // Run first copy-reducers with Melinda-configs and then the specific MelindaReducers
-  const reducers = [...MelindaCopyReducerConfigs.map(conf => Reducers.copy(conf)), ...MelindaReducers];
+
+  const reducers = recordType === 'bib' ? [...MelindaCopyReducerConfigs.map(conf => Reducers.copy(conf)), ...MelindaReducers] : undefined;
+
+  if (!reducers) {
+    debug(`No reducers!`);
+    throw new MergeError(HttpStatus.INTERNAL_SERVER_ERROR, `No merge-reducers specified for ${recordType} records!`);
+  }
 
   debugData(`Reducers: ${inspect(reducers, {colors: true, maxArrayLength: 10, depth: 8})})}`);
 


### PR DESCRIPTION
* Use undefined searcSpec and detectionStrategy for recordType 'autname'

* Use empty list of matchOptions for recordType 'autname'

* Error match if there are no defined matcher or the amount of matchers and matcherOptions differs

* Disallow use of 'unique' or 'merge' functionalities if recordType is not 'bib'

* Specify mergeReducers for 'bib'

* Error merge if there are no specified mergeReducers