### PR TITLE
Update match validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@natlibfi/melinda-backend-commons": "^2.1.0",
 				"@natlibfi/melinda-commons": "^12.0.4",
 				"@natlibfi/melinda-marc-record-merge-reducers": "1.0.0-alpha.6",
-				"@natlibfi/melinda-record-match-validator": "^1.0.1-alpha.1",
+				"@natlibfi/melinda-record-match-validator": "^1.1.0-alpha.2",
 				"@natlibfi/melinda-record-matching": "^2.2.1-alpha.2",
 				"@natlibfi/melinda-rest-api-commons": "^2.3.2-alpha.4",
 				"@natlibfi/sru-client": "^5.0.3",
@@ -2107,9 +2107,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-match-validator": {
-			"version": "1.0.1-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-match-validator/-/melinda-record-match-validator-1.0.1-alpha.1.tgz",
-			"integrity": "sha512-xlg9vQDei26sNeK2sWrysIS+7RDC56Eu/yG8AFJmx9/46M1i4MQLblMZWv+dauyypDo9HK97mwJISaIzhc9rkQ==",
+			"version": "1.1.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-match-validator/-/melinda-record-match-validator-1.1.0-alpha.2.tgz",
+			"integrity": "sha512-aNAWKSUuWcja3d4yh6NPUWnQL3JZfhjhSGypBZwOB8QGVgQoouaJewIuhx7BYiw0S692V3medetOwERIdUQQ2Q==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^7.2.1",
 				"@natlibfi/melinda-commons": "^12.0.4",
@@ -9334,9 +9334,9 @@
 			}
 		},
 		"@natlibfi/melinda-record-match-validator": {
-			"version": "1.0.1-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-match-validator/-/melinda-record-match-validator-1.0.1-alpha.1.tgz",
-			"integrity": "sha512-xlg9vQDei26sNeK2sWrysIS+7RDC56Eu/yG8AFJmx9/46M1i4MQLblMZWv+dauyypDo9HK97mwJISaIzhc9rkQ==",
+			"version": "1.1.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-match-validator/-/melinda-record-match-validator-1.1.0-alpha.2.tgz",
+			"integrity": "sha512-aNAWKSUuWcja3d4yh6NPUWnQL3JZfhjhSGypBZwOB8QGVgQoouaJewIuhx7BYiw0S692V3medetOwERIdUQQ2Q==",
 			"requires": {
 				"@natlibfi/marc-record": "^7.2.1",
 				"@natlibfi/melinda-commons": "^12.0.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"@natlibfi/melinda-backend-commons": "^2.1.0",
 		"@natlibfi/melinda-commons": "^12.0.4",
 		"@natlibfi/melinda-marc-record-merge-reducers": "1.0.0-alpha.6",
-		"@natlibfi/melinda-record-match-validator": "^1.0.1-alpha.1",
+		"@natlibfi/melinda-record-match-validator": "^1.1.0-alpha.2",
 		"@natlibfi/melinda-record-matching": "^2.2.1-alpha.2",
 		"@natlibfi/melinda-rest-api-commons": "^2.3.2-alpha.4",
 		"@natlibfi/sru-client": "^5.0.3",

--- a/src/interfaces/validator/match-validation.js
+++ b/src/interfaces/validator/match-validation.js
@@ -29,11 +29,13 @@ export async function matchValidationForMatchResults(record, matchResults) {
   // This could be optimized so that it would be done when it finds the first valid match?
 
   const matchResultsAndMatchValidations = await matchResultClone.map(match => {
-    // format candidate to MelindaInternalFormat
     debug(`Validating match to candidateRecord ${match.candidate.id}`);
     const candidateRecord = match.candidate.record;
+    const record1External = {recordType: 'incomingRecord'};
+    const record2External = {recordType: 'databaseRecord'};
     //debug(candidateRecord);
-    const matchValidationResult = matchValidation(record, candidateRecord);
+
+    const matchValidationResult = matchValidation({record1: record, record2: candidateRecord, record1External, record2External});
     return {
       ...matchValidationResult,
       ...match
@@ -74,11 +76,11 @@ export async function matchValidationForMatchResults(record, matchResults) {
 }
 
 // melinda-record-match-validation is *NOT* async
-export function matchValidation(recordA, recordB) {
+export function matchValidation({record1, record2, record1External, record2External}) {
   debug(`Running match-validation here:`);
-  debug(`recorA: ${recordA.constructor.name}`);
+  debug(`recorA: ${record1.constructor.name}`);
   // Send records to match-validator as plain objects to avoid problems with differing MarcRecord -versions etc.
-  const matchValidationResult = matchValidator(recordA.toObject(), recordB.toObject());
+  const matchValidationResult = matchValidator({record1Object: record1.toObject(), record2Object: record2.toObject(), record1External, record2External});
   debugData(inspect(matchValidationResult));
   return matchValidationResult;
 }


### PR DESCRIPTION
- Update melinda-record-match-validator to v1.1.0 -- Compare detailed prePublicationLevel from note fields for determining merge preference for prePublication records -- Prefer incomingRecord when both records are prePublication records and the detailed prePublicationLevel is same