### PR TITLE
Skip changes to f008 creationDate

### DIFF
--- a/src/interfaces/validator/validate-changes.js
+++ b/src/interfaces/validator/validate-changes.js
@@ -30,11 +30,14 @@ import deepEqual from 'deep-eql';
 import {detailedDiff} from 'deep-object-diff';
 import createDebugLogger from 'debug';
 import {normalizeEmptySubfieldsRecord} from '../../utils';
+import {MarcRecord} from '@natlibfi/marc-record';
+
+const debug = createDebugLogger('@natlibfi/melinda-rest-api-validator:validator:validate-changes');
+const debugData = debug.extend('data');
 
 // Checks that the incomingRecord and existingRecord are not identical
+// eslint-disable-next-line max-statements
 export function validateChanges({incomingRecord, existingRecord, validate = true}) {
-  const debug = createDebugLogger('@natlibfi/melinda-rest-api-validator:validator:validate-changes');
-  const debugData = debug.extend('data');
 
   if (validate === false) {
     debug(`Skipping validateChanges. Validate: ${validate}`);
@@ -49,13 +52,10 @@ export function validateChanges({incomingRecord, existingRecord, validate = true
     return {changeValidationResult: true};
   }
 
-
-  // normalizeEmptySubfieldsRecord is an utility function which normalizes all all cases of empty subfield value {code: x, value: ""}, {code: x}, {code: x, value: undefined}  to {value: ""}
-  // this is needed, because there are CAT-fields that have empty value in subfield $b
-  // we could optimize this step out, if we could be sure that empty subfield values are normalized somewhere else
-
-  const normIncomingRecord = normalizeEmptySubfieldsRecord(incomingRecord);
-  const normExistingRecord = normalizeEmptySubfieldsRecord(existingRecord);
+  //debug(`ic`);
+  const normIncomingRecord = normalizeRecord(incomingRecord);
+  //debug(`db`);
+  const normExistingRecord = normalizeRecord(existingRecord);
 
   if (deepEqual(normIncomingRecord, normExistingRecord) === true) { // eslint-disable-line functional/no-conditional-statement
 
@@ -73,3 +73,48 @@ export function validateChanges({incomingRecord, existingRecord, validate = true
 
   return {changeValidationResult: true};
 }
+
+function normalizeRecord(record) {
+
+  debug(`Normalizing record: empty subfields`);
+  //debugData(record);
+  // normalizeEmptySubfieldsRecord is an utility function which normalizes all all cases of empty subfield value {code: x, value: ""}, {code: x}, {code: x, value: undefined}  to {value: ""}
+  // this is needed, because there are CAT-fields that have empty value in subfield $b
+  // we could optimize this step out, if we could be sure that empty subfield values are normalized somewhere else
+
+  const normRecord1 = normalizeEmptySubfieldsRecord(record);
+  debug(`Normalizing record: f008/00-05`);
+  // Normalize f008/00-05 - In non-MARC21 imports f008 'Date entered on file' gets always the current date
+  // This propably should be configurable
+  //debugData(normRecord1);
+  const normRecord = emptyf008CreationDate(normRecord1);
+
+  return normRecord;
+}
+
+function emptyf008CreationDate(record) {
+  debugData(record);
+  const controlFields = record.getControlfields();
+  const normControlFields = controlFields.map(emptyf008);
+  //debugData(JSON.stringify(controlFields));
+
+  const dataFields = record.getDatafields();
+  const fields = normControlFields.concat(dataFields);
+  //debugData(fields);
+  return new MarcRecord({leader: record.leader, fields}, {subfieldValues: false});
+
+  function emptyf008(controlfield) {
+    if (controlfield.tag !== '008' || controlfield.value.length < 6) {
+      return controlfield;
+    }
+    return {tag: controlfield.tag, value: emptyCreationDate(controlfield.value)};
+  }
+
+  function emptyCreationDate(f008value) {
+    const newValue = `000000${f008value.substring(6)}`;
+    debug(`Emptied creationDate from ${f008value} to ${newValue}`);
+    return newValue;
+  }
+
+}
+

--- a/test-fixtures/validate-changes/07/metadata.json
+++ b/test-fixtures/validate-changes/07/metadata.json
@@ -1,0 +1,8 @@
+{
+    "description": "Should return false if the only change is in f008/00-05",
+    "comment": "In non-MARC21 imports f008 'Date entered on file' gets always the current date",
+    "expectedResult": false,
+    "expectedToThrow": false,
+    "enabled": true,
+    "only": false
+  }

--- a/test-fixtures/validate-changes/07/record1.json
+++ b/test-fixtures/validate-changes/07/record1.json
@@ -1,0 +1,124 @@
+{
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      {
+        "tag": "001",
+        "value": "000019640"
+      },
+      {
+        "tag": "008",
+        "value": "230210s2023 fi |||||o|||||||||||fin||"
+      },
+      {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "978-952-62-2477-0"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      },
+      {
+        "tag": "245",
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "foo."
+          },
+          {
+            "code": "b",
+            "value": "bar"
+          }
+        ]
+      },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-VIOLA"
+        },
+        {
+          "code": "b",
+          "value": ""
+        },
+        {
+          "code": "c",
+          "value": "20190607"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "1430"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-ID"
+        },
+        {
+          "code": "b",
+          "value": "00"
+        },
+        {
+          "code": "c",
+          "value": "20190713"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "0021"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-ID"
+        },
+        {
+          "code": "b",
+          "value": "00"
+        },
+        {
+          "code": "c",
+          "value": "20190831"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "0125"
+        }
+      ]
+    }
+    ]
+  }

--- a/test-fixtures/validate-changes/07/record2.json
+++ b/test-fixtures/validate-changes/07/record2.json
@@ -1,0 +1,124 @@
+{
+  "leader": "02518cam a2200745zi 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "000019640"
+    },
+    {
+      "tag": "008",
+      "value": "230209s2023 fi |||||o|||||||||||fin||"
+    },
+    {
+      "tag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "978-952-62-2477-0"
+        },
+        {
+          "code": "q",
+          "value": "PDF"
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "1",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "foo."
+        },
+        {
+          "code": "b",
+          "value": "bar"
+        }
+      ]
+    },
+
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-VIOLA"
+        },
+        {
+          "code": "b"
+        },
+        {
+          "code": "c",
+          "value": "20190607"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "1430"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-ID"
+        },
+        {
+          "code": "b",
+          "value": "00"
+        },
+        {
+          "code": "c",
+          "value": "20190713"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "0021"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-ID"
+        },
+        {
+          "code": "b",
+          "value": "00"
+        },
+        {
+          "code": "c",
+          "value": "20190831"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "0125"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
When *skipNoChangeUpdates* is active and the only change between incoming record and existing record is in f008/00-05 creationDate ('Date entered on file'), change can be skipped.
- Non-marc21 import creates f008/00-05 always as the current date

