### PR TITLE
Update matching: v4.1.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@natlibfi/melinda-commons": "^13.0.2",
 				"@natlibfi/melinda-marc-record-merge-reducers": "^1.2.0",
 				"@natlibfi/melinda-record-match-validator": "^2.0.3-alpha.1",
-				"@natlibfi/melinda-record-matching": "^4.1.0-alpha.1",
+				"@natlibfi/melinda-record-matching": "^4.1.0-alpha.2",
 				"@natlibfi/melinda-rest-api-commons": "^3.0.6",
 				"@natlibfi/sru-client": "^5.0.4",
 				"deep-eql": "^4.1.3",
@@ -3591,9 +3591,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-matching": {
-			"version": "4.1.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-4.1.0-alpha.1.tgz",
-			"integrity": "sha512-MhjXs/QofeSo3RQPYPcJaiSc6cSjirZsk+y0B8mTJGQEXRCi5QT4WZwdu5ygV6Rc2p+nYRoCZl6BOFthzecjLw==",
+			"version": "4.1.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-4.1.0-alpha.2.tgz",
+			"integrity": "sha512-sr+8sYz7RNPaPnMNbecqW+RPLcCrootHn/K9yrllg1RNO7RI+G8o0bMpvdNyWRJSDS0MgBNjBawpFOMhh4VF2A==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^7.2.2",
 				"@natlibfi/marc-record-serializers": "^9.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.2.4-alpha.1",
+	"version": "3.2.4-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.2.4-alpha.1",
+			"version": "3.2.4-alpha.2",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@natlibfi/melinda-commons": "^13.0.2",
 		"@natlibfi/melinda-marc-record-merge-reducers": "^1.2.0",
 		"@natlibfi/melinda-record-match-validator": "^2.0.3-alpha.1",
-		"@natlibfi/melinda-record-matching": "^4.1.0-alpha.1",
+		"@natlibfi/melinda-record-matching": "^4.1.0-alpha.2",
 		"@natlibfi/melinda-rest-api-commons": "^3.0.6",
 		"@natlibfi/sru-client": "^5.0.4",
 		"deep-eql": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.2.4-alpha.1",
+	"version": "3.2.4-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/src/config.js
+++ b/src/config.js
@@ -181,8 +181,12 @@ function generateStrategy(validatorMatchPackage) {
         matchDetection.features.bib.authors(),
         // We probably should have some leeway here for notated music as BK etc.
         matchDetection.features.bib.recordType(),
-        // Use publicationTimeAllowConsYears to ignore one year differences in publicationTime
-        matchDetection.features.bib.publicationTimeAllowConsYears(),
+        // Use publicationTimeAllowConsYearsMulti to
+        //  - ignore one year differences in publicationTime
+        //  - extract publicationTimes from f008, f26x and reprint notes in f500
+        //  - do not substract points for mismatching (normal) publicationTime, if there's a match between
+        //       normal publicationTime and a reprintPublication time
+        matchDetection.features.bib.publicationTimeAllowConsYearsMulti(),
         matchDetection.features.bib.language(),
         matchDetection.features.bib.bibliographicLevel()
       ];


### PR DESCRIPTION
* Update matching: v4.1.0-alpha.2

* Use publicationTimeAllowConsYearsMulti in STANDARD_IDS matchPackage 
** extract publicationTimes from f008, f26x and reprint notes in f500
** ignore one year differences in (normal) publicationTime
** do not substract points for mismatching (normal) publicationTime, if there's a match between normal publicationTime and a reprintPublication time

