### PR TITLE
Create and log matcherReports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.3.5",
+	"version": "3.3.6-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.3.5",
+			"version": "3.3.6-alpha.1",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.3.5",
+	"version": "3.3.6-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,7 @@ export const splitterOptions = {
 const validatorMatchPackages = readEnvironmentVariable('VALIDATOR_MATCH_PACKAGES', {defaultValue: 'IDS,STANDARD_IDS,CONTENT'}).split(',');
 const stopWhenFound = readEnvironmentVariable('STOP_WHEN_FOUND', {defaultValue: 1, format: v => parseBoolean(v)});
 const acceptZeroWithMaxCandidates = readEnvironmentVariable('ACCEPT_ZERO_WITH_MAX_CANDIDATES', {defaultValue: 0, format: v => parseBoolean(v)});
-
+const logNoMatches = readEnvironmentVariable('LOG_NO_MATCHES', {defaultValue: 0, format: v => parseBoolean(v)});
 
 // We could have also settings matchValidation and merge here
 
@@ -42,7 +42,8 @@ export const validatorOptions = {
   sruUrl: readEnvironmentVariable('SRU_URL'),
   matchOptionsList: generateMatchOptionsList(),
   stopWhenFound,
-  acceptZeroWithMaxCandidates
+  acceptZeroWithMaxCandidates,
+  logNoMatches
 };
 
 function generateMatchOptionsList() {

--- a/src/interfaces/validator/index.js
+++ b/src/interfaces/validator/index.js
@@ -483,6 +483,16 @@ export default async function ({preValidationFixOptions, postMergeFixOptions, pr
     // matchResultsForLog is an array of matchResult objects:
     // {action, preference: {name, value}, message, candidate: {id, record}, probability, matchSequence}
 
+    // add information from matcherReports to matchResults
+    const matchResultsWithReports = matchResultsForLog.map((result) => {
+      const matcherReportsForMatch = matcherReports.filter((matcherReport) => matcherReport && matcherReport.matchIds && matcherReport.matchIds.includes(result.candidate.id));
+      logger.debug(`${JSON.stringify(matcherReportsForMatch)}`);
+      return {
+        ...result,
+        matcherReports: matcherReportsForMatch
+      };
+    });
+
     const matchLogItem = {
       logItemType: LOG_ITEM_TYPE.MATCH_LOG,
       cataloger: catalogerForLog,
@@ -490,7 +500,7 @@ export default async function ({preValidationFixOptions, postMergeFixOptions, pr
       blobSequence: headers.recordMetadata.blobSequence,
       ...headers.recordMetadata,
       incomingRecord: record,
-      matchResult: matchResultsForLog,
+      matchResult: matchResultsWithReports,
       matcherReports
     };
 

--- a/src/interfaces/validator/index.js
+++ b/src/interfaces/validator/index.js
@@ -477,7 +477,7 @@ export default async function ({preValidationFixOptions, postMergeFixOptions, pr
 
   function logMatchAction({headers, record, matchResultsForLog = [], matcherReports, logNoMatches = false}) {
 
-    if (logNoMatches && matchResultsForLog.length < 1) {
+    if (!logNoMatches && matchResultsForLog.length < 1) {
       logger.debug(`No matches, logNoMatches: ${logNoMatches} - not logging matchAction to mongoLogs`);
       return;
     }

--- a/src/interfaces/validator/match.js
+++ b/src/interfaces/validator/match.js
@@ -10,7 +10,7 @@ const logger = createLogger();
 // acceptZeroWithMaxCandidates = do not error if we get a zero match result with matchStatus: false and stopReason: maxCandidates
 
 // eslint-disable-next-line max-statements
-export async function iterateMatchers({matchers, matchOptionsList, record, stopWhenFound = true, acceptZeroWithMaxCandidates = false, matcherCount = 0, matcherNoRunCount = 0, matcherFalseZeroCounts = {maxCandidates: 0, maxedQueries: 0, conversionFailures: 0}, matcherReports = {}, allConversionFailures = [], allMatches = [], allStatus = true}) {
+export async function iterateMatchers({matchers, matchOptionsList, record, stopWhenFound = true, acceptZeroWithMaxCandidates = false, matcherCount = 0, matcherNoRunCount = 0, matcherFalseZeroCounts = {maxCandidates: 0, maxedQueries: 0, conversionFailures: 0}, matcherReports = [], allConversionFailures = [], allMatches = [], allStatus = true}) {
   logger.debug(`Matchers left: ${matchers.length}`);
 
   const [matcher] = matchers;
@@ -75,7 +75,8 @@ export async function iterateMatchers({matchers, matchOptionsList, record, stopW
         matcherName,
         matchAmount,
         candidateCount,
-        conversionFailureCount: conversionFailures.length
+        conversionFailureCount: conversionFailures.length,
+        matchStatus
       };
 
       const newMatcherReports = matcherReports.concat(matcherReport);
@@ -100,7 +101,7 @@ export async function iterateMatchers({matchers, matchOptionsList, record, stopW
 
       const {matcherFalseZeroCounts: newMatcherFalseZeroCounts} = checkStopReasonForZeroMatches({matchAmount, matchStatus, matcherFalseZeroCounts, matcherCount: newMatcherCount, matcherName});
 
-      return iterateMatchers({matchers: matchers.slice(1), matchOptionsList: matchOptionsList.slice(1), stopWhenFound, acceptZeroWithMaxCandidates, record, matcherCount, matcherNoRunCount, matcherFalseZeroCounts: newMatcherFalseZeroCounts, matcherReports: newMatcherReports, allConversionFailures: newConversionFailures, allMatches: newMatches, allStatus: newAllStatus});
+      return iterateMatchers({matchers: matchers.slice(1), matchOptionsList: matchOptionsList.slice(1), stopWhenFound, acceptZeroWithMaxCandidates, record, matcherCount: newMatcherCount, matcherNoRunCount, matcherFalseZeroCounts: newMatcherFalseZeroCounts, matcherReports: newMatcherReports, allConversionFailures: newConversionFailures, allMatches: newMatches, allStatus: newAllStatus});
 
     } catch (err) {
 
@@ -230,7 +231,7 @@ function checkStopReasonForZeroMatches({matchAmount, matcherCount, matcherName, 
     if (matchStatus.status === false && matchStatus.stopReason === 'conversionFailures') {
       logger.verbose(`Matcher ${matcherName} resulted in ${matchStatus.status}, stopReason ${matchStatus.stopReason}`);
       // eslint-disable-next-line no-param-reassign, functional/immutable-data
-      matcherFalseZeroCounts.cnversionFailures += 1;
+      matcherFalseZeroCounts.conversionFailures += 1;
     }
   }
   return {matcherFalseZeroCounts};

--- a/src/interfaces/validator/match.js
+++ b/src/interfaces/validator/match.js
@@ -69,7 +69,7 @@ export async function iterateMatchers({matchers, matchOptionsList, record, stopW
       const newMatches = allMatches.concat(matches);
       const newAllStatus = matchStatus.status === false ? false : allStatus;
       const matchAmount = matches.length;
-      const matchIds = matchers.map(({candidate: {id}}) => id);
+      const matchIds = matches.map(({candidate: {id}}) => id);
 
       const matcherReport = {
         matcherSequence: newmatcherSequence,

--- a/src/interfaces/validator/match.js
+++ b/src/interfaces/validator/match.js
@@ -40,6 +40,7 @@ export async function iterateMatchers({matchers, matchOptionsList, record, stopW
       // - treshold (if returnStrategy option is true)
       // - matchQuery (if returnQuery option is true)
       // conversionFailures: array of errors contents ({status, payload: {message, id, data}}) (if returnFailures is true)
+      // candidateCount: amount of matchCandidates that matcher retrieved from the database for matchDetection before stopping
 
       // we could have here also returnRecords/returnMatchRecords/returnNonMatchRecord options that could be turned false for not to return actual record data
 
@@ -50,19 +51,19 @@ export async function iterateMatchers({matchers, matchOptionsList, record, stopW
 
       // Note: candidate.record is in external format (as it is fetched from SRU) - we keep also the incoming record in external format to avoid problems
 
-      //const matchResults = await matcher(record);
-
       // We could have also some kind of id for the incomingRecord here (blobSequence?)
       const recordExternal = {recordSource: 'incomingRecord', label: 'ic'};
       const matchResults = await matcher({record, recordExternal});
 
-      const {matches, matchStatus, conversionFailures} = matchResults;
+      const {matches, matchStatus, conversionFailures, candidateCount} = matchResults;
 
       logger.debug(`MatchStatus: ${JSON.stringify(matchStatus)})`);
       logger.silly(`MatchResult: ${inspect(matchResults, {colors: true, maxArrayLength: 10, depth: 3})}`);
 
       logger.debug(`Conversion failures: ${conversionFailures.length}`);
       logger.silly(`Conversion failures: ${JSON.stringify(conversionFailures.map(f => f.payload.id))}`);
+
+      logger.debug(`CandidateCount: ${JSON.stringify(candidateCount)})`);
 
       // We probably want to log conversionFailures somewhere here - currently conversionFailures are logged only when matching fails due to them
       const newConversionFailures = allConversionFailures.concat(...conversionFailures);
@@ -73,6 +74,7 @@ export async function iterateMatchers({matchers, matchOptionsList, record, stopW
 
       // How we should handle cases, where matchResult is false, but we did get match(es)?
       // Should we return also information about the matcher that hit the match (to recognize matches by recordIDs vs other matches?)
+      // What should we do with candidateCount? We'd like to pass it on, in case of recordID or standardNumber matchCandidates that were not detected as matches
 
       if (stopWhenFound && matchAmount > 0) {
 

--- a/src/interfaces/validator/match.js
+++ b/src/interfaces/validator/match.js
@@ -69,6 +69,7 @@ export async function iterateMatchers({matchers, matchOptionsList, record, stopW
       const newMatches = allMatches.concat(matches);
       const newAllStatus = matchStatus.status === false ? false : allStatus;
       const matchAmount = matches.length;
+      const matchIds = matchers.map(({candidate: {id}}) => id);
 
       const matcherReport = {
         matcherSequence: newmatcherSequence,
@@ -76,7 +77,8 @@ export async function iterateMatchers({matchers, matchOptionsList, record, stopW
         matchAmount,
         candidateCount,
         conversionFailureCount: conversionFailures.length,
-        matchStatus
+        matchStatus,
+        matchIds
       };
 
       const newMatcherReports = matcherReports.concat(matcherReport);


### PR DESCRIPTION
Improve logging matching results
* receive candidateCount from matcher
* create matcherReport for each iterated matcher
* add matcherReports to MATCH_LOG
* add configurable option to create MATCH_LOG also when there are no matches found
