### PR TITLE
Create and log matcherReports (#182)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.3.5",
+	"version": "3.3.6-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.3.5",
+			"version": "3.3.6-alpha.2",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.3.5",
+	"version": "3.3.6-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,7 @@ export const splitterOptions = {
 const validatorMatchPackages = readEnvironmentVariable('VALIDATOR_MATCH_PACKAGES', {defaultValue: 'IDS,STANDARD_IDS,CONTENT'}).split(',');
 const stopWhenFound = readEnvironmentVariable('STOP_WHEN_FOUND', {defaultValue: 1, format: v => parseBoolean(v)});
 const acceptZeroWithMaxCandidates = readEnvironmentVariable('ACCEPT_ZERO_WITH_MAX_CANDIDATES', {defaultValue: 0, format: v => parseBoolean(v)});
-
+const logNoMatches = readEnvironmentVariable('LOG_NO_MATCHES', {defaultValue: 0, format: v => parseBoolean(v)});
 
 // We could have also settings matchValidation and merge here
 
@@ -42,7 +42,8 @@ export const validatorOptions = {
   sruUrl: readEnvironmentVariable('SRU_URL'),
   matchOptionsList: generateMatchOptionsList(),
   stopWhenFound,
-  acceptZeroWithMaxCandidates
+  acceptZeroWithMaxCandidates,
+  logNoMatches
 };
 
 function generateMatchOptionsList() {


### PR DESCRIPTION
_Improve logging matching results_

* receive candidateCount from matcher
* create matcherReport for each iterated matcher
* add matcherReports to MATCH_LOG
* add configurable option to create MATCH_LOG also when there are no matches found

* 3.3.6-alpha.2