### PR TITLE
Dependencies (#230)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.3.14",
+	"version": "3.3.15-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.3.14",
+			"version": "3.3.15-alpha.1",
 			"license": "AGPL-3.0+",
 			"dependencies": {
-				"@babel/runtime": "^7.22.6",
+				"@babel/runtime": "^7.22.10",
 				"@natlibfi/marc-record": "7.2.4",
-				"@natlibfi/marc-record-merge": "7.0.0-alpha.1",
-				"@natlibfi/marc-record-serializers": "^10.0.6",
+				"@natlibfi/marc-record-merge": "7.0.0",
+				"@natlibfi/marc-record-serializers": "^10.0.7",
 				"@natlibfi/marc-record-validate": "^8.0.1",
 				"@natlibfi/marc-record-validators-melinda": "^10.9.3",
 				"@natlibfi/melinda-backend-commons": "^2.2.1",
@@ -28,13 +28,13 @@
 				"moment": "^2.29.4"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.22.9",
-				"@babel/core": "^7.22.9",
-				"@babel/eslint-parser": "^7.22.9",
-				"@babel/node": "^7.22.6",
-				"@babel/preset-env": "^7.22.9",
+				"@babel/cli": "^7.22.10",
+				"@babel/core": "^7.22.10",
+				"@babel/eslint-parser": "^7.22.10",
+				"@babel/node": "^7.22.10",
+				"@babel/preset-env": "^7.22.10",
 				"@babel/register": "^7.22.5",
-				"@natlibfi/eslint-config-melinda-backend": "^3.0.0",
+				"@natlibfi/eslint-config-melinda-backend": "^3.0.1",
 				"@natlibfi/fixugen-http-server": "^1.1.6",
 				"@natlibfi/fixura": "^3.0.1",
 				"babel-plugin-istanbul": "^6.1.1",
@@ -828,9 +828,9 @@
 			"optional": true
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.22.9.tgz",
-			"integrity": "sha512-nb2O7AThqRo7/E53EGiuAkMaRbb7J5Qp3RvN+dmua1U+kydm0oznkhqbTEG15yk26G/C3yL6OdZjzgl+DMXVVA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.22.10.tgz",
+			"integrity": "sha512-rM9ZMmaII630zGvtMtQ3P4GyHs28CHLYE9apLG7L8TgaSqcfoIGrlLSLsh4Q8kDTdZQQEXZm1M0nQtOvU/2heg==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -857,11 +857,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-			"integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
+			"integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
 			"dependencies": {
-				"@babel/highlight": "^7.22.5"
+				"@babel/highlight": "^7.22.10",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -876,20 +877,20 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
-			"integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+			"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.22.5",
-				"@babel/generator": "^7.22.9",
-				"@babel/helper-compilation-targets": "^7.22.9",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-compilation-targets": "^7.22.10",
 				"@babel/helper-module-transforms": "^7.22.9",
-				"@babel/helpers": "^7.22.6",
-				"@babel/parser": "^7.22.7",
+				"@babel/helpers": "^7.22.10",
+				"@babel/parser": "^7.22.10",
 				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.8",
-				"@babel/types": "^7.22.5",
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -905,9 +906,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.9.tgz",
-			"integrity": "sha512-xdMkt39/nviO/4vpVdrEYPwXCsYIXSSAr6mC7WQsNIlGnuxKyKE7GZjalcnbSWiC4OXGNNN3UQPeHfjSC6sTDA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.10.tgz",
+			"integrity": "sha512-0J8DNPRXQRLeR9rPaUMM3fA+RbixjnVLe/MRMYCkp3hzgsSuxCHQ8NN8xQG1wIHKJ4a1DTROTvFJdW+B5/eOsg==",
 			"dev": true,
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -918,16 +919,16 @@
 				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": ">=7.11.0",
+				"@babel/core": "^7.11.0",
 				"eslint": "^7.5.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-			"integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
+			"integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
 			"dependencies": {
-				"@babel/types": "^7.22.5",
+				"@babel/types": "^7.22.10",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -961,9 +962,9 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.9.tgz",
-			"integrity": "sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
+			"integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
 			"dependencies": {
 				"@babel/compat-data": "^7.22.9",
 				"@babel/helper-validator-option": "^7.22.5",
@@ -973,9 +974,6 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
@@ -1128,15 +1126,14 @@
 			}
 		},
 		"node_modules/@babel/helper-remap-async-to-generator": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.5.tgz",
-			"integrity": "sha512-cU0Sq1Rf4Z55fgz7haOakIyM7+x/uCFwXpLPaeRzfoUtAEAuUZjZvFPjL/rk5rW693dIgn2hng1W7xbT7lWT4g==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.9.tgz",
+			"integrity": "sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
 				"@babel/helper-environment-visitor": "^7.22.5",
-				"@babel/helper-wrap-function": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/helper-wrap-function": "^7.22.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1221,40 +1218,39 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.5.tgz",
-			"integrity": "sha512-bYqLIBSEshYcYQyfks8ewYA8S30yaGSeRslcvKMvoUk6HHPySbxHq9YRi6ghhzEU+yhQv9bP/jXnygkStOcqZw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.10.tgz",
+			"integrity": "sha512-OnMhjWjuGYtdoO3FmsEFWvBStBAe2QOgwOLsLNDjN+aaiMD8InJk1/O3HSD8lkqTjCgg5YI34Tz15KNNA3p+nQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-function-name": "^7.22.5",
 				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.22.10"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
-			"integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
+			"integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
 			"dependencies": {
 				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.6",
-				"@babel/types": "^7.22.5"
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-			"integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
+			"integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.22.5",
-				"chalk": "^2.0.0",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -1262,16 +1258,16 @@
 			}
 		},
 		"node_modules/@babel/node": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.6.tgz",
-			"integrity": "sha512-Lt6v+RUQOTsEOXLv+KfjogLFkFfsLPPSoXZqmbngfVatkWjQPnFGHO0xjFRcN6XEvm3vsnZn+AWQiRpgZFsdIA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.10.tgz",
+			"integrity": "sha512-FpSgdjIPabpEetDxtKYAcXCs0qRh12S2D40rhpRoo0w5h7/7Tu2ZroaX99cbKFNDODiSs484sZ1q0kutJbZ2iQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/register": "^7.22.5",
 				"commander": "^4.0.1",
 				"core-js": "^3.30.2",
 				"node-environment-flags": "^1.0.5",
-				"regenerator-runtime": "^0.13.11",
+				"regenerator-runtime": "^0.14.0",
 				"v8flags": "^3.1.1"
 			},
 			"bin": {
@@ -1285,9 +1281,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-			"integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
+			"integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1334,22 +1330,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz",
-			"integrity": "sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=4"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -1606,14 +1586,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.7.tgz",
-			"integrity": "sha512-7HmE7pk/Fmke45TODvxvkxRMV9RazV+ZZzhOL9AG8G29TLrr3jkjwF7uJfxZ30EoXpO+LJkq4oA8NjO2DTnEDg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.10.tgz",
+			"integrity": "sha512-eueE8lvKVzq5wIObKK/7dvoeKJ+xc6TvRn6aysIjS6pSCeLy7S/eVi7pEQknZqyqvzaNKdDtem8nUNTBgDVR2g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.5",
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-remap-async-to-generator": "^7.22.5",
+				"@babel/helper-remap-async-to-generator": "^7.22.9",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			},
 			"engines": {
@@ -1656,9 +1636,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.5.tgz",
-			"integrity": "sha512-EcACl1i5fSQ6bt+YGuU/XGCeZKStLmyVGytWkpyhCLeQVA0eu6Wtiw92V+I1T/hnezUv7j74dA/Ro69gWcU+hg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.10.tgz",
+			"integrity": "sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1743,9 +1723,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.5.tgz",
-			"integrity": "sha512-GfqcFuGW8vnEqTUBM7UtPd5A4q797LTvvwKxXTgRsFjoqaJiEg9deBG6kWeQYkVEL569NpnmpC0Pkr/8BLKGnQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.10.tgz",
+			"integrity": "sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -2112,9 +2092,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.6.tgz",
-			"integrity": "sha512-Vd5HiWml0mDVtcLHIoEU5sw6HOUW/Zk0acLs/SAeuLzkGNOPc9DB4nkUajemhCmTIz3eiaKREZn2hQQqF79YTg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.10.tgz",
+			"integrity": "sha512-MMkQqZAZ+MGj+jGTG3OTuhKeBpNcO+0oCEbrGNEaOmiEn+1MzRyQlYsruGiU8RTK3zV6XwrVJTmwiDOyYK6J9g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -2193,13 +2173,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.22.5.tgz",
-			"integrity": "sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.22.10.tgz",
+			"integrity": "sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"regenerator-transform": "^0.15.1"
+				"regenerator-transform": "^0.15.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2300,9 +2280,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-escapes": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.22.5.tgz",
-			"integrity": "sha512-biEmVg1IYB/raUO5wT1tgfacCef15Fbzhkx493D3urBI++6hpJ+RFG4SrWMn0NEZLfvilqKf3QDrRVZHo08FYg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.22.10.tgz",
+			"integrity": "sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -2363,13 +2343,13 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.9.tgz",
-			"integrity": "sha512-wNi5H/Emkhll/bqPjsjQorSykrlfY5OWakd6AulLvMEytpKasMVUpVy8RL4qBIBs5Ac6/5i0/Rv0b/Fg6Eag/g==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.10.tgz",
+			"integrity": "sha512-riHpLb1drNkpLlocmSyEg4oYJIQFeXAK/d7rI6mbD0XsvoTOOweXDmQPG/ErxsEhWk3rl3Q/3F6RFQlVFS8m0A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.22.9",
-				"@babel/helper-compilation-targets": "^7.22.9",
+				"@babel/helper-compilation-targets": "^7.22.10",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-validator-option": "^7.22.5",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.5",
@@ -2394,15 +2374,15 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.22.5",
-				"@babel/plugin-transform-async-generator-functions": "^7.22.7",
+				"@babel/plugin-transform-async-generator-functions": "^7.22.10",
 				"@babel/plugin-transform-async-to-generator": "^7.22.5",
 				"@babel/plugin-transform-block-scoped-functions": "^7.22.5",
-				"@babel/plugin-transform-block-scoping": "^7.22.5",
+				"@babel/plugin-transform-block-scoping": "^7.22.10",
 				"@babel/plugin-transform-class-properties": "^7.22.5",
 				"@babel/plugin-transform-class-static-block": "^7.22.5",
 				"@babel/plugin-transform-classes": "^7.22.6",
 				"@babel/plugin-transform-computed-properties": "^7.22.5",
-				"@babel/plugin-transform-destructuring": "^7.22.5",
+				"@babel/plugin-transform-destructuring": "^7.22.10",
 				"@babel/plugin-transform-dotall-regex": "^7.22.5",
 				"@babel/plugin-transform-duplicate-keys": "^7.22.5",
 				"@babel/plugin-transform-dynamic-import": "^7.22.5",
@@ -2425,27 +2405,27 @@
 				"@babel/plugin-transform-object-rest-spread": "^7.22.5",
 				"@babel/plugin-transform-object-super": "^7.22.5",
 				"@babel/plugin-transform-optional-catch-binding": "^7.22.5",
-				"@babel/plugin-transform-optional-chaining": "^7.22.6",
+				"@babel/plugin-transform-optional-chaining": "^7.22.10",
 				"@babel/plugin-transform-parameters": "^7.22.5",
 				"@babel/plugin-transform-private-methods": "^7.22.5",
 				"@babel/plugin-transform-private-property-in-object": "^7.22.5",
 				"@babel/plugin-transform-property-literals": "^7.22.5",
-				"@babel/plugin-transform-regenerator": "^7.22.5",
+				"@babel/plugin-transform-regenerator": "^7.22.10",
 				"@babel/plugin-transform-reserved-words": "^7.22.5",
 				"@babel/plugin-transform-shorthand-properties": "^7.22.5",
 				"@babel/plugin-transform-spread": "^7.22.5",
 				"@babel/plugin-transform-sticky-regex": "^7.22.5",
 				"@babel/plugin-transform-template-literals": "^7.22.5",
 				"@babel/plugin-transform-typeof-symbol": "^7.22.5",
-				"@babel/plugin-transform-unicode-escapes": "^7.22.5",
+				"@babel/plugin-transform-unicode-escapes": "^7.22.10",
 				"@babel/plugin-transform-unicode-property-regex": "^7.22.5",
 				"@babel/plugin-transform-unicode-regex": "^7.22.5",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
-				"@babel/preset-modules": "^0.1.5",
-				"@babel/types": "^7.22.5",
-				"babel-plugin-polyfill-corejs2": "^0.4.4",
-				"babel-plugin-polyfill-corejs3": "^0.8.2",
-				"babel-plugin-polyfill-regenerator": "^0.5.1",
+				"@babel/preset-modules": "0.1.6-no-external-plugins",
+				"@babel/types": "^7.22.10",
+				"babel-plugin-polyfill-corejs2": "^0.4.5",
+				"babel-plugin-polyfill-corejs3": "^0.8.3",
+				"babel-plugin-polyfill-regenerator": "^0.5.2",
 				"core-js-compat": "^3.31.0",
 				"semver": "^6.3.1"
 			},
@@ -2457,19 +2437,17 @@
 			}
 		},
 		"node_modules/@babel/preset-modules": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
-			"integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
+			"version": "0.1.6-no-external-plugins",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+			"integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
 				"@babel/types": "^7.4.4",
 				"esutils": "^2.0.2"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
+				"@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/@babel/register": {
@@ -2497,11 +2475,11 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-			"integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+			"integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
 			"dependencies": {
-				"regenerator-runtime": "^0.13.11"
+				"regenerator-runtime": "^0.14.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2521,18 +2499,18 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.22.8",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-			"integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+			"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.5",
-				"@babel/generator": "^7.22.7",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
 				"@babel/helper-environment-visitor": "^7.22.5",
 				"@babel/helper-function-name": "^7.22.5",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.22.7",
-				"@babel/types": "^7.22.5",
+				"@babel/parser": "^7.22.10",
+				"@babel/types": "^7.22.10",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -2541,9 +2519,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-			"integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
+			"integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.22.5",
 				"@babel/helper-validator-identifier": "^7.22.5",
@@ -2791,9 +2769,9 @@
 			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"node_modules/@natlibfi/eslint-config-melinda-backend": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.0.tgz",
-			"integrity": "sha512-Nn/jPwvwSY44xczjDiU0eR4t3Awbfc/nYrromiSn6Atx7h6V87rcXrAr1E1QtXKDWg/+7b36zNdBxO5mkaBliA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.1.tgz",
+			"integrity": "sha512-9DLr4o0hoSR7YToevR9IIES5btPr83ZvYqbzI6vMRkrcQKjQLCVBTGKKBQA4z7e2ZhI45grbN61tj7m4sNV3+Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/eslint-parser": "^7.21.3",
@@ -2861,11 +2839,11 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-merge": {
-			"version": "7.0.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-merge/-/marc-record-merge-7.0.0-alpha.1.tgz",
-			"integrity": "sha512-gaZk1mjxVU8mGz56TZCpYyHBwCPF1DNY9D3CK3wa84Osk/BOBehRu4dWpIryI85KtOE/7eBeJTvApFy9DTr61A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-merge/-/marc-record-merge-7.0.0.tgz",
+			"integrity": "sha512-O5j0oltR2wSkxPD6A4vyeOZZJhhQGAiQDLBCNKx8H1s7f7IcxPBO8oNjJY6lrboh/gTYap1D3U67zgMYjRh12A==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^7.2.2",
+				"@natlibfi/marc-record": "^7.2.4",
 				"debug": "^4.3.4",
 				"normalize-diacritics": "^2.13.2"
 			},
@@ -2874,11 +2852,11 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.0.6.tgz",
-			"integrity": "sha512-EXiJatZ7JFC9pk0e5eCh3CFvi54ONS+qQEqI1lQ5FpSSxLTWp18amlh9sZt7vDpJGuWzHpiGFWElo6qE2lIHpg==",
+			"version": "10.0.7",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.0.7.tgz",
+			"integrity": "sha512-Nzm8RYf2Fx54iuTPRCi3PJvfLoKYY3ZiXaI0I6T0VPbYoYHi+r0Rt8weEVjEzubmRi9Q42+SgQrPj/sgcrijNw==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^7.2.2",
+				"@natlibfi/marc-record": "^7.2.4",
 				"@xmldom/xmldom": "^0.8.10",
 				"stream-json": "^1.8.0",
 				"xml2js": ">=0.6.2 <1.0.0",
@@ -8539,14 +8517,14 @@
 			}
 		},
 		"node_modules/regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
 		},
 		"node_modules/regenerator-transform": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
-			"integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+			"integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.8.4"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.3.14",
+	"version": "3.3.15-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -34,10 +34,10 @@
 		"dev": "NODE_ENV=development cross-env nodemon"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.22.6",
+		"@babel/runtime": "^7.22.10",
 		"@natlibfi/marc-record": "7.2.4",
-		"@natlibfi/marc-record-merge": "7.0.0-alpha.1",
-		"@natlibfi/marc-record-serializers": "^10.0.6",
+		"@natlibfi/marc-record-merge": "7.0.0",
+		"@natlibfi/marc-record-serializers": "^10.0.7",
 		"@natlibfi/marc-record-validate": "^8.0.1",
 		"@natlibfi/marc-record-validators-melinda": "^10.9.3",
 		"@natlibfi/melinda-backend-commons": "^2.2.1",
@@ -53,13 +53,13 @@
 		"moment": "^2.29.4"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.22.9",
-		"@babel/core": "^7.22.9",
-		"@babel/eslint-parser": "^7.22.9",
-		"@babel/node": "^7.22.6",
-		"@babel/preset-env": "^7.22.9",
+		"@babel/cli": "^7.22.10",
+		"@babel/core": "^7.22.10",
+		"@babel/eslint-parser": "^7.22.10",
+		"@babel/node": "^7.22.10",
+		"@babel/preset-env": "^7.22.10",
 		"@babel/register": "^7.22.5",
-		"@natlibfi/eslint-config-melinda-backend": "^3.0.0",
+		"@natlibfi/eslint-config-melinda-backend": "^3.0.1",
 		"@natlibfi/fixugen-http-server": "^1.1.6",
 		"@natlibfi/fixura": "^3.0.1",
 		"babel-plugin-istanbul": "^6.1.1",


### PR DESCRIPTION
* Bump @natlibfi/marc-record-serializers from 10.0.6 to 10.0.7 (#229)
* Bump @babel/runtime from 7.22.6 to 7.22.10 (#228)

* Update deps

* 3.3.15-alpha.1