### PR TITLE
Update merge (MET-456)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@natlibfi/marc-record-validators-melinda": "^10.9.3",
 				"@natlibfi/melinda-backend-commons": "^2.2.1",
 				"@natlibfi/melinda-commons": "^13.0.5",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.12",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.13-alpha.1",
 				"@natlibfi/melinda-record-match-validator": "^2.0.6",
 				"@natlibfi/melinda-record-matching": "^4.1.3",
 				"@natlibfi/melinda-rest-api-commons": "^4.0.7",
@@ -2954,18 +2954,18 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.0.12.tgz",
-			"integrity": "sha512-3G1pi7E8xygOYJjsDn0mcGjjUjAAdyq5p8qeLDgZVv1+C2xMVKVCzBtEAeuwgOQry/1FMLJVGEwo7s6G32dcww==",
+			"version": "2.0.13-alpha.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.0.13-alpha.1.tgz",
+			"integrity": "sha512-yZ/t5tr0rPWl7pfTnx4SxeH0/iNotagwCCx1WhDFdwdwjKG1ayBLQUPLZ7clCbQKD04WJLsyOOa+9lgnf5LISQ==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-merge": "^7.0.0-alpha.1",
+				"@natlibfi/marc-record": "^7.2.4",
+				"@natlibfi/marc-record-merge": "^7.0.0-alpha.4",
 				"@natlibfi/marc-record-validate": "^8.0.1",
 				"@natlibfi/marc-record-validators-melinda": "^10.9.3",
 				"@natlibfi/melinda-commons": "^13.0.5",
 				"clone": "^2.1.2",
 				"debug": "^4.3.4",
-				"isbn3": "^1.1.39",
+				"isbn3": "^1.1.40",
 				"normalize-diacritics": "^4.0.0"
 			},
 			"engines": {
@@ -6829,9 +6829,9 @@
 			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
 		},
 		"node_modules/isbn3": {
-			"version": "1.1.39",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.39.tgz",
-			"integrity": "sha512-QFn6w6mU2GHuisITR14u6uG08d1U902yBQAKwY5BEfcv8v+q3OHbcgj1m7jrUjTj7aZ8fOvfvGMSpKR4xkLsYw==",
+			"version": "1.1.40",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.40.tgz",
+			"integrity": "sha512-4WfuisxbThzIirb6pxrY8ZR+gsaVDfqhTaxKe4bKLlT1it9yd3wBVbWxYrgO6n2MPLMFXUymiUDKFJ8UpWPhtg==",
 			"bin": {
 				"isbn": "bin/isbn",
 				"isbn-audit": "bin/isbn-audit",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.3.15-alpha.1",
+	"version": "3.3.15-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.3.15-alpha.1",
+			"version": "3.3.15-alpha.2",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.22.10",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.3.15-alpha.1",
+	"version": "3.3.15-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@natlibfi/marc-record-validators-melinda": "^10.9.3",
 		"@natlibfi/melinda-backend-commons": "^2.2.1",
 		"@natlibfi/melinda-commons": "^13.0.5",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.12",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.13-alpha.1",
 		"@natlibfi/melinda-record-match-validator": "^2.0.6",
 		"@natlibfi/melinda-record-matching": "^4.1.3",
 		"@natlibfi/melinda-rest-api-commons": "^4.0.7",


### PR DESCRIPTION
* Update merge-reducers: v2.0.13-alpha.1
** Keep f264 $a from non-preferred record in more cases where it's missing from preferred record 
** https://github.com/NatLibFi/melinda-marc-record-merge-reducers-js/pull/71