### PR TITLE
Update merge (#306)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@natlibfi/marc-record-validators-melinda": "^10.15.1",
 				"@natlibfi/melinda-backend-commons": "^2.2.2",
 				"@natlibfi/melinda-commons": "^13.0.7",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21-alpha.2",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21",
 				"@natlibfi/melinda-record-match-validator": "^2.0.8",
 				"@natlibfi/melinda-record-matching": "^4.2.0",
 				"@natlibfi/melinda-rest-api-commons": "^4.0.19",
@@ -3081,9 +3081,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "2.0.21-alpha.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.0.21-alpha.2.tgz",
-			"integrity": "sha512-ZfM9NP5cKQ180V7twtugpHtkUDtHj2QxCm7uwee3q1ihUKwAeObGyQNVnrkFyJgCLyBKT+4equluRTwU4XaL/A==",
+			"version": "2.0.21",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.0.21.tgz",
+			"integrity": "sha512-SCOzvUbOCsBxrNC1SR+eUDgZlLG1SI79X9T74P6entsNlwjz4P+NDU7z5i9JJN3yvQgOnkwHdUnRd28hzR6eSQ==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.0.0",
 				"@natlibfi/marc-record-merge": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@natlibfi/marc-record-validators-melinda": "^10.15.1",
 				"@natlibfi/melinda-backend-commons": "^2.2.2",
 				"@natlibfi/melinda-commons": "^13.0.7",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21-alpha.1",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21-alpha.2",
 				"@natlibfi/melinda-record-match-validator": "^2.0.8",
 				"@natlibfi/melinda-record-matching": "^4.2.0",
 				"@natlibfi/melinda-rest-api-commons": "^4.0.19",
@@ -3081,9 +3081,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "2.0.21-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.0.21-alpha.1.tgz",
-			"integrity": "sha512-2IpON/cHaZXUOPq2DETzAW/htJD6POkG9yoyhOkNvmvpiABsssXQl3jVmp4iB0qs+mcRf+PODnjV68/hhCklKQ==",
+			"version": "2.0.21-alpha.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.0.21-alpha.2.tgz",
+			"integrity": "sha512-ZfM9NP5cKQ180V7twtugpHtkUDtHj2QxCm7uwee3q1ihUKwAeObGyQNVnrkFyJgCLyBKT+4equluRTwU4XaL/A==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.0.0",
 				"@natlibfi/marc-record-merge": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.4.8-alpha.1",
+	"version": "3.4.8-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.4.8-alpha.1",
+			"version": "3.4.8-alpha.2",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.23.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.4.7",
+	"version": "3.4.8-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.4.7",
+			"version": "3.4.8-alpha.1",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.23.2",
@@ -17,7 +17,7 @@
 				"@natlibfi/marc-record-validators-melinda": "^10.15.1",
 				"@natlibfi/melinda-backend-commons": "^2.2.2",
 				"@natlibfi/melinda-commons": "^13.0.7",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.20",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21-alpha.1",
 				"@natlibfi/melinda-record-match-validator": "^2.0.8",
 				"@natlibfi/melinda-record-matching": "^4.2.0",
 				"@natlibfi/melinda-rest-api-commons": "^4.0.19",
@@ -3081,9 +3081,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "2.0.20",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.0.20.tgz",
-			"integrity": "sha512-RvjWWxkfAb0KUrPfw4Dki9v5x4Km4KidRh6U8+3jEvuSmp18xthOj7+m/gI6ATp42FAirrMNd5KtPeyjSukJ0g==",
+			"version": "2.0.21-alpha.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.0.21-alpha.1.tgz",
+			"integrity": "sha512-2IpON/cHaZXUOPq2DETzAW/htJD6POkG9yoyhOkNvmvpiABsssXQl3jVmp4iB0qs+mcRf+PODnjV68/hhCklKQ==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.0.0",
 				"@natlibfi/marc-record-merge": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@natlibfi/marc-record-validators-melinda": "^10.15.1",
 		"@natlibfi/melinda-backend-commons": "^2.2.2",
 		"@natlibfi/melinda-commons": "^13.0.7",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21-alpha.2",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21",
 		"@natlibfi/melinda-record-match-validator": "^2.0.8",
 		"@natlibfi/melinda-record-matching": "^4.2.0",
 		"@natlibfi/melinda-rest-api-commons": "^4.0.19",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.4.7",
+	"version": "3.4.8-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -42,7 +42,7 @@
 		"@natlibfi/marc-record-validators-melinda": "^10.15.1",
 		"@natlibfi/melinda-backend-commons": "^2.2.2",
 		"@natlibfi/melinda-commons": "^13.0.7",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.20",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21-alpha.1",
 		"@natlibfi/melinda-record-match-validator": "^2.0.8",
 		"@natlibfi/melinda-record-matching": "^4.2.0",
 		"@natlibfi/melinda-rest-api-commons": "^4.0.19",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.4.8-alpha.1",
+	"version": "3.4.8-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@natlibfi/marc-record-validators-melinda": "^10.15.1",
 		"@natlibfi/melinda-backend-commons": "^2.2.2",
 		"@natlibfi/melinda-commons": "^13.0.7",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21-alpha.1",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^2.0.21-alpha.2",
 		"@natlibfi/melinda-record-match-validator": "^2.0.8",
 		"@natlibfi/melinda-record-matching": "^4.2.0",
 		"@natlibfi/melinda-rest-api-commons": "^4.0.19",

--- a/src/interfaces/validator/validations.js
+++ b/src/interfaces/validator/validations.js
@@ -285,7 +285,8 @@ export async function validationsFactory(
         const newNote = `No new incoming changes from ${catalogerForLog} detected while trying to update existing record ${firstResult.candidate.id}, update skipped.`;
         const updatedHeaders = {
           operation: 'SKIPPED_UPDATE',
-          notes: headers.notes ? headers.notes.concat(`${newNote}`) : [newNote]
+          notes: headers.notes ? headers.notes.concat(`${newNote}`) : [newNote],
+          id: firstResult?.candidate?.id || headers.id
         };
         const finalHeaders = {...headers, ...updatedHeaders};
         return {result: {record, validationResult: false}, recordMetadata, headers: finalHeaders};


### PR DESCRIPTION
* Update merge-reducers: v2.0.21-alpha.1

Permit merge of field 884 [MET-502]
- Fix MET-502: make field 884 mergeable, set merge constraints for it. Also fix a bug in field counterpart decisions. (Controlfields $5 and $9 were used in name&title part comparisons, if no subfield code was required. Removed these controlfields from comparisons).

Better handling of publishers [MELINDA-8978]
- If source has an Asteri $0, and the counterpart base field has not, use the source field as the field, to which the other fields' subfields are merged.

* 3.4.8-alpha.1