### PR TITLE
Fix id in skipped update [MRA-741]

### DIFF
--- a/src/interfaces/validator/validations.js
+++ b/src/interfaces/validator/validations.js
@@ -285,7 +285,8 @@ export async function validationsFactory(
         const newNote = `No new incoming changes from ${catalogerForLog} detected while trying to update existing record ${firstResult.candidate.id}, update skipped.`;
         const updatedHeaders = {
           operation: 'SKIPPED_UPDATE',
-          notes: headers.notes ? headers.notes.concat(`${newNote}`) : [newNote]
+          notes: headers.notes ? headers.notes.concat(`${newNote}`) : [newNote],
+          id: firstResult?.candidate?.id || headers.id
         };
         const finalHeaders = {...headers, ...updatedHeaders};
         return {result: {record, validationResult: false}, recordMetadata, headers: finalHeaders};


### PR DESCRIPTION
Include databaseRecords's id in SKIPPED_UPDATE recordResponse's databaseId instead of blobSequence