### PR TITLE
Add aut main Webhooks (#444) ; Dependency updates (#443, #452)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,36 +1,36 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.6.5-alpha.3",
+	"version": "3.6.5-alpha.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.6.5-alpha.3",
+			"version": "3.6.5-alpha.4",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.25.0",
+				"@babel/runtime": "^7.25.6",
 				"@natlibfi/marc-record": "^9.0.1",
 				"@natlibfi/marc-record-merge": "^7.0.5",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
 				"@natlibfi/melinda-backend-commons": "^2.3.1",
-				"@natlibfi/melinda-commons": "^13.0.16",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^2.2.5",
+				"@natlibfi/melinda-commons": "^13.0.17",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.0",
 				"@natlibfi/melinda-record-match-validator": "^2.2.3",
 				"@natlibfi/melinda-record-matching": "^4.3.3",
 				"@natlibfi/melinda-rest-api-commons": "^4.1.10",
 				"@natlibfi/sru-client": "^6.0.14",
-				"debug": "^4.3.6",
+				"debug": "^4.3.7",
 				"deep-eql": "^4.1.4",
 				"deep-object-diff": "^1.1.9",
 				"http-status": "^1.7.4"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.24.8",
+				"@babel/cli": "^7.25.6",
 				"@babel/core": "^7.25.2",
 				"@babel/node": "^7.25.0",
-				"@babel/plugin-transform-runtime": "^7.24.7",
-				"@babel/preset-env": "^7.25.3",
+				"@babel/plugin-transform-runtime": "^7.25.4",
+				"@babel/preset-env": "^7.25.4",
 				"@babel/register": "^7.24.6",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
 				"@natlibfi/fixugen": "^2.0.9",
@@ -127,9 +127,9 @@
 			}
 		},
 		"node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-crypto/sha256-js": {
@@ -147,9 +147,9 @@
 			}
 		},
 		"node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-crypto/supports-web-crypto": {
@@ -162,9 +162,9 @@
 			}
 		},
 		"node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-crypto/util": {
@@ -217,53 +217,53 @@
 			}
 		},
 		"node_modules/@aws-crypto/util/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.632.0.tgz",
-			"integrity": "sha512-ciPZZ0jxMmXuaKCVdJthWogfqJ/4nb1zCxm7D/XkKcSbANjAiJ+1l+yiu7ZPTLGKKPRQQkPsWUknw5xb/5LxeQ==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.645.0.tgz",
+			"integrity": "sha512-nBfWDzWBQI1NCHYqBAmiifhdnLRxQYozaq6OjTuRcALjYJbOdFV7t0w9FWGISOq1OnM7r8UdCXlr2bzdyU0tJA==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.632.0",
-				"@aws-sdk/client-sts": "3.632.0",
-				"@aws-sdk/core": "3.629.0",
-				"@aws-sdk/credential-provider-node": "3.632.0",
+				"@aws-sdk/client-sso-oidc": "3.645.0",
+				"@aws-sdk/client-sts": "3.645.0",
+				"@aws-sdk/core": "3.635.0",
+				"@aws-sdk/credential-provider-node": "3.645.0",
 				"@aws-sdk/middleware-host-header": "3.620.0",
 				"@aws-sdk/middleware-logger": "3.609.0",
 				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.632.0",
+				"@aws-sdk/middleware-user-agent": "3.645.0",
 				"@aws-sdk/region-config-resolver": "3.614.0",
 				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.632.0",
+				"@aws-sdk/util-endpoints": "3.645.0",
 				"@aws-sdk/util-user-agent-browser": "3.609.0",
 				"@aws-sdk/util-user-agent-node": "3.614.0",
 				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.2",
+				"@smithy/core": "^2.4.0",
 				"@smithy/fetch-http-handler": "^3.2.4",
 				"@smithy/hash-node": "^3.0.3",
 				"@smithy/invalid-dependency": "^3.0.3",
 				"@smithy/middleware-content-length": "^3.0.5",
 				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.14",
+				"@smithy/middleware-retry": "^3.0.15",
 				"@smithy/middleware-serde": "^3.0.3",
 				"@smithy/middleware-stack": "^3.0.3",
 				"@smithy/node-config-provider": "^3.1.4",
 				"@smithy/node-http-handler": "^3.1.4",
 				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
 				"@smithy/url-parser": "^3.0.3",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.14",
-				"@smithy/util-defaults-mode-node": "^3.0.14",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
 				"@smithy/util-endpoints": "^2.0.5",
 				"@smithy/util-middleware": "^3.0.3",
 				"@smithy/util-retry": "^3.0.3",
@@ -275,50 +275,50 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.632.0.tgz",
-			"integrity": "sha512-iYWHiKBz44m3chCFvtvHnvCpL2rALzyr1e6tOZV3dLlOKtQtDUlPy6OtnXDu4y+wyJCniy8ivG3+LAe4klzn1Q==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.645.0.tgz",
+			"integrity": "sha512-2rc8TjnsNddOeKQ/pfNN7deNvGLXAeKeYtHtGDAiM2qfTKxd2sNcAsZ+JCDLyshuD4xLM5fpUyR0X8As9EAouQ==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.629.0",
+				"@aws-sdk/core": "3.635.0",
 				"@aws-sdk/middleware-host-header": "3.620.0",
 				"@aws-sdk/middleware-logger": "3.609.0",
 				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.632.0",
+				"@aws-sdk/middleware-user-agent": "3.645.0",
 				"@aws-sdk/region-config-resolver": "3.614.0",
 				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.632.0",
+				"@aws-sdk/util-endpoints": "3.645.0",
 				"@aws-sdk/util-user-agent-browser": "3.609.0",
 				"@aws-sdk/util-user-agent-node": "3.614.0",
 				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.2",
+				"@smithy/core": "^2.4.0",
 				"@smithy/fetch-http-handler": "^3.2.4",
 				"@smithy/hash-node": "^3.0.3",
 				"@smithy/invalid-dependency": "^3.0.3",
 				"@smithy/middleware-content-length": "^3.0.5",
 				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.14",
+				"@smithy/middleware-retry": "^3.0.15",
 				"@smithy/middleware-serde": "^3.0.3",
 				"@smithy/middleware-stack": "^3.0.3",
 				"@smithy/node-config-provider": "^3.1.4",
 				"@smithy/node-http-handler": "^3.1.4",
 				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
 				"@smithy/url-parser": "^3.0.3",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.14",
-				"@smithy/util-defaults-mode-node": "^3.0.14",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
 				"@smithy/util-endpoints": "^2.0.5",
 				"@smithy/util-middleware": "^3.0.3",
 				"@smithy/util-retry": "^3.0.3",
@@ -330,45 +330,45 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.632.0.tgz",
-			"integrity": "sha512-Oh1fIWaoZluihOCb/zDEpRTi+6an82fgJz7fyRBugyLhEtDjmvpCQ3oKjzaOhoN+4EvXAm1ZS/ZgpvXBlIRTgw==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.645.0.tgz",
+			"integrity": "sha512-X9ULtdk3cO+1ysurEkJ1MSnu6U00qodXx+IVual+1jXX4RYY1WmQmfo7uDKf6FFkz7wW1DAqU+GJIBNQr0YH8A==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.629.0",
-				"@aws-sdk/credential-provider-node": "3.632.0",
+				"@aws-sdk/core": "3.635.0",
+				"@aws-sdk/credential-provider-node": "3.645.0",
 				"@aws-sdk/middleware-host-header": "3.620.0",
 				"@aws-sdk/middleware-logger": "3.609.0",
 				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.632.0",
+				"@aws-sdk/middleware-user-agent": "3.645.0",
 				"@aws-sdk/region-config-resolver": "3.614.0",
 				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.632.0",
+				"@aws-sdk/util-endpoints": "3.645.0",
 				"@aws-sdk/util-user-agent-browser": "3.609.0",
 				"@aws-sdk/util-user-agent-node": "3.614.0",
 				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.2",
+				"@smithy/core": "^2.4.0",
 				"@smithy/fetch-http-handler": "^3.2.4",
 				"@smithy/hash-node": "^3.0.3",
 				"@smithy/invalid-dependency": "^3.0.3",
 				"@smithy/middleware-content-length": "^3.0.5",
 				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.14",
+				"@smithy/middleware-retry": "^3.0.15",
 				"@smithy/middleware-serde": "^3.0.3",
 				"@smithy/middleware-stack": "^3.0.3",
 				"@smithy/node-config-provider": "^3.1.4",
 				"@smithy/node-http-handler": "^3.1.4",
 				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
 				"@smithy/url-parser": "^3.0.3",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.14",
-				"@smithy/util-defaults-mode-node": "^3.0.14",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
 				"@smithy/util-endpoints": "^2.0.5",
 				"@smithy/util-middleware": "^3.0.3",
 				"@smithy/util-retry": "^3.0.3",
@@ -379,62 +379,62 @@
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.632.0"
+				"@aws-sdk/client-sts": "^3.645.0"
 			}
 		},
 		"node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-sso/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-sts": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.632.0.tgz",
-			"integrity": "sha512-Ss5cBH09icpTvT+jtGGuQlRdwtO7RyE9BF4ZV/CEPATdd9whtJt4Qxdya8BUnkWR7h5HHTrQHqai3YVYjku41A==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.645.0.tgz",
+			"integrity": "sha512-6azXYtvtnAsPf2ShN9vKynIYVcJOpo6IoVmoMAVgNaBJyllP+s/RORzranYZzckqfmrudSxtct4rVapjLWuAMg==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.632.0",
-				"@aws-sdk/core": "3.629.0",
-				"@aws-sdk/credential-provider-node": "3.632.0",
+				"@aws-sdk/client-sso-oidc": "3.645.0",
+				"@aws-sdk/core": "3.635.0",
+				"@aws-sdk/credential-provider-node": "3.645.0",
 				"@aws-sdk/middleware-host-header": "3.620.0",
 				"@aws-sdk/middleware-logger": "3.609.0",
 				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.632.0",
+				"@aws-sdk/middleware-user-agent": "3.645.0",
 				"@aws-sdk/region-config-resolver": "3.614.0",
 				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.632.0",
+				"@aws-sdk/util-endpoints": "3.645.0",
 				"@aws-sdk/util-user-agent-browser": "3.609.0",
 				"@aws-sdk/util-user-agent-node": "3.614.0",
 				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.2",
+				"@smithy/core": "^2.4.0",
 				"@smithy/fetch-http-handler": "^3.2.4",
 				"@smithy/hash-node": "^3.0.3",
 				"@smithy/invalid-dependency": "^3.0.3",
 				"@smithy/middleware-content-length": "^3.0.5",
 				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.14",
+				"@smithy/middleware-retry": "^3.0.15",
 				"@smithy/middleware-serde": "^3.0.3",
 				"@smithy/middleware-stack": "^3.0.3",
 				"@smithy/node-config-provider": "^3.1.4",
 				"@smithy/node-http-handler": "^3.1.4",
 				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
 				"@smithy/url-parser": "^3.0.3",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.14",
-				"@smithy/util-defaults-mode-node": "^3.0.14",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
 				"@smithy/util-endpoints": "^2.0.5",
 				"@smithy/util-middleware": "^3.0.3",
 				"@smithy/util-retry": "^3.0.3",
@@ -446,23 +446,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sts/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.629.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
-			"integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
+			"version": "3.635.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.635.0.tgz",
+			"integrity": "sha512-i1x/E/sgA+liUE1XJ7rj1dhyXpAKO1UKFUcTTHXok2ARjWTvszHnSXMOsB77aPbmn0fUp1JTx2kHUAZ1LVt5Bg==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/core": "^2.3.2",
+				"@smithy/core": "^2.4.0",
 				"@smithy/node-config-provider": "^3.1.4",
 				"@smithy/property-provider": "^3.1.3",
 				"@smithy/protocol-http": "^4.1.0",
 				"@smithy/signature-v4": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
 				"@smithy/util-middleware": "^3.0.3",
 				"fast-xml-parser": "4.4.1",
@@ -473,18 +473,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/core/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.632.0.tgz",
-			"integrity": "sha512-fr+xCIqMYsUD67vwE/IpboIqHiEYMQMrpPjnvpbbvyjTKspFh0GS7Qn1LVFCd5oNeu1rzAdJei1On2HBOwIiZQ==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.645.0.tgz",
+			"integrity": "sha512-Z4By/90TaYQZO1dPR1udYhegFiOlSWnZsJOYSAk4Gdny26Tqb78xVLw9R/33CzFblXC4WVSt4gizXTQ/sYyHNg==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.632.0",
+				"@aws-sdk/client-cognito-identity": "3.645.0",
 				"@aws-sdk/types": "3.609.0",
 				"@smithy/property-provider": "^3.1.3",
 				"@smithy/types": "^3.3.0",
@@ -495,9 +495,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
@@ -516,15 +516,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.622.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
-			"integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
+			"version": "3.635.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.635.0.tgz",
+			"integrity": "sha512-iJyRgEjOCQlBMXqtwPLIKYc7Bsc6nqjrZybdMDenPDa+kmLg7xh8LxHsu9088e+2/wtLicE34FsJJIfzu3L82g==",
 			"optional": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.609.0",
@@ -532,7 +532,7 @@
 				"@smithy/node-http-handler": "^3.1.4",
 				"@smithy/property-provider": "^3.1.3",
 				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
 				"@smithy/util-stream": "^3.1.3",
 				"tslib": "^2.6.2"
@@ -542,21 +542,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.632.0.tgz",
-			"integrity": "sha512-m6epoW41xa1ajU5OiHcmQHoGVtrbXBaRBOUhlCLZmcaqMLYsboM4iD/WZP8aatKEON5tTnVXh/4StV8D/+wemw==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.645.0.tgz",
+			"integrity": "sha512-LlZW0qwUwNlTaAIDCNpLbPsyXvS42pRIwF92fgtCQedmdnpN3XRUC6hcwSYI7Xru3GGKp3RnceOvsdOaRJORsw==",
 			"optional": true,
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "3.620.1",
-				"@aws-sdk/credential-provider-http": "3.622.0",
+				"@aws-sdk/credential-provider-http": "3.635.0",
 				"@aws-sdk/credential-provider-process": "3.620.1",
-				"@aws-sdk/credential-provider-sso": "3.632.0",
+				"@aws-sdk/credential-provider-sso": "3.645.0",
 				"@aws-sdk/credential-provider-web-identity": "3.621.0",
 				"@aws-sdk/types": "3.609.0",
 				"@smithy/credential-provider-imds": "^3.2.0",
@@ -569,26 +569,26 @@
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.632.0"
+				"@aws-sdk/client-sts": "^3.645.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.632.0.tgz",
-			"integrity": "sha512-cL8fuJWm/xQBO4XJPkeuZzl3XinIn9EExWgzpG48NRMKR5us1RI/ucv7xFbBBaG+r/sDR2HpYBIA3lVIpm1H3Q==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.645.0.tgz",
+			"integrity": "sha512-eGFFuNvLeXjCJf5OCIuSEflxUowmK+bCS+lK4M8ofsYOEGAivdx7C0UPxNjHpvM8wKd8vpMl5phTeS9BWX5jMQ==",
 			"optional": true,
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "3.620.1",
-				"@aws-sdk/credential-provider-http": "3.622.0",
-				"@aws-sdk/credential-provider-ini": "3.632.0",
+				"@aws-sdk/credential-provider-http": "3.635.0",
+				"@aws-sdk/credential-provider-ini": "3.645.0",
 				"@aws-sdk/credential-provider-process": "3.620.1",
-				"@aws-sdk/credential-provider-sso": "3.632.0",
+				"@aws-sdk/credential-provider-sso": "3.645.0",
 				"@aws-sdk/credential-provider-web-identity": "3.621.0",
 				"@aws-sdk/types": "3.609.0",
 				"@smithy/credential-provider-imds": "^3.2.0",
@@ -602,9 +602,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
@@ -624,18 +624,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.632.0.tgz",
-			"integrity": "sha512-P/4wB6j7ym5QCPTL2xlMfvf2NcXSh+z0jmsZP4WW/tVwab4hvgabPPbLeEZDSWZ0BpgtxKGvRq0GSHuGeirQbA==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.645.0.tgz",
+			"integrity": "sha512-d6XuChAl5NCsCrUexc6AFb4efPmb9+66iwPylKG+iMTMYgO1ackfy1Q2/f35jdn0jolkPkzKsVyfzsEVoID6ew==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.632.0",
+				"@aws-sdk/client-sso": "3.645.0",
 				"@aws-sdk/token-providers": "3.614.0",
 				"@aws-sdk/types": "3.609.0",
 				"@smithy/property-provider": "^3.1.3",
@@ -648,9 +648,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
@@ -672,27 +672,27 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.632.0.tgz",
-			"integrity": "sha512-Q4x2ARdgncZKOJE/NXJHY5s8/YDRugVUR4lBEtibE764w5ezAhI1aMChzAzv4j3WMSDZ29KyxaymHHt2vJED9g==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.645.0.tgz",
+			"integrity": "sha512-6g9qMngrMCvHNsxmh/1urnWKrvaa2fv55b3bYwPxwJCYAvg/xc7bV8YHL7GS2rJpACG707k9G86DTW+Hab8bJA==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.632.0",
-				"@aws-sdk/client-sso": "3.632.0",
-				"@aws-sdk/client-sts": "3.632.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.632.0",
+				"@aws-sdk/client-cognito-identity": "3.645.0",
+				"@aws-sdk/client-sso": "3.645.0",
+				"@aws-sdk/client-sts": "3.645.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.645.0",
 				"@aws-sdk/credential-provider-env": "3.620.1",
-				"@aws-sdk/credential-provider-http": "3.622.0",
-				"@aws-sdk/credential-provider-ini": "3.632.0",
-				"@aws-sdk/credential-provider-node": "3.632.0",
+				"@aws-sdk/credential-provider-http": "3.635.0",
+				"@aws-sdk/credential-provider-ini": "3.645.0",
+				"@aws-sdk/credential-provider-node": "3.645.0",
 				"@aws-sdk/credential-provider-process": "3.620.1",
-				"@aws-sdk/credential-provider-sso": "3.632.0",
+				"@aws-sdk/credential-provider-sso": "3.645.0",
 				"@aws-sdk/credential-provider-web-identity": "3.621.0",
 				"@aws-sdk/types": "3.609.0",
 				"@smithy/credential-provider-imds": "^3.2.0",
@@ -705,9 +705,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
@@ -726,9 +726,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
@@ -746,9 +746,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
@@ -767,19 +767,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.632.0.tgz",
-			"integrity": "sha512-yY/sFsHKwG9yzSf/DTclqWJaGPI2gPBJDCGBujSqTG1zlS7Ot4fqi91DZ6088BFWzbOorDzJFcAhAEFzc6LuQg==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.645.0.tgz",
+			"integrity": "sha512-NpTAtqWK+49lRuxfz7st9for80r4NriCMK0RfdJSoPFVntjsSQiQ7+2nW2XL05uVY633e9DvCAw8YatX3zd1mw==",
 			"optional": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.632.0",
+				"@aws-sdk/util-endpoints": "3.645.0",
 				"@smithy/protocol-http": "^4.1.0",
 				"@smithy/types": "^3.3.0",
 				"tslib": "^2.6.2"
@@ -789,9 +789,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/region-config-resolver": {
@@ -812,9 +812,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/token-providers": {
@@ -837,9 +837,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/types": {
@@ -856,15 +856,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/types/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.632.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.632.0.tgz",
-			"integrity": "sha512-LlYMU8pAbcEQphOpE6xaNLJ8kPGhklZZTVzZVpVW477NaaGgoGTMYNXTABYHcxeF5E2lLrxql9OmVpvr8GWN8Q==",
+			"version": "3.645.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.645.0.tgz",
+			"integrity": "sha512-Oe+xaU4ic4PB1k3pb5VTC1/MWES13IlgpaQw01bVHGfwP6Yv6zZOxizRzca2Y3E+AyR+nKD7vXtHRY+w3bi4bg==",
 			"optional": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.609.0",
@@ -877,9 +877,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
@@ -895,9 +895,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
@@ -913,9 +913,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
@@ -942,15 +942,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.24.8.tgz",
-			"integrity": "sha512-isdp+G6DpRyKc+3Gqxy2rjzgF7Zj9K0mzLNnxz+E/fgeag8qT3vVulX4gY9dGO1q0y+0lUv6V3a+uhUzMzrwXg==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.25.6.tgz",
+			"integrity": "sha512-Z+Doemr4VtvSD2SNHTrkiFZ1LX+JI6tyRXAAOb4N9khIuPyoEPmTPJarPm8ljJV1D6bnMQjyHMWTT9NeKbQuXA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
@@ -970,7 +970,7 @@
 			},
 			"optionalDependencies": {
 				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
-				"chokidar": "^3.4.0"
+				"chokidar": "^3.6.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -1044,11 +1044,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.25.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
-			"integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+			"integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
 			"dependencies": {
-				"@babel/types": "^7.25.4",
+				"@babel/types": "^7.25.6",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
@@ -1312,12 +1312,12 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-			"integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+			"integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
 			"dependencies": {
 				"@babel/template": "^7.25.0",
-				"@babel/types": "^7.25.0"
+				"@babel/types": "^7.25.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1361,11 +1361,11 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.25.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
-			"integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+			"integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
 			"dependencies": {
-				"@babel/types": "^7.25.4"
+				"@babel/types": "^7.25.6"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1529,12 +1529,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.7.tgz",
-			"integrity": "sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.25.6.tgz",
+			"integrity": "sha512-aABl0jHw9bZ2karQ/uUD6XP4u0SG22SJrOHFoL6XB1R7dTovOP4TzTlsxOYC5yQ1pdscVK2JTUnF6QL3ARoAiQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1544,12 +1544,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.7.tgz",
-			"integrity": "sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
+			"integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2641,9 +2641,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.25.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.4.tgz",
-			"integrity": "sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+			"integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -2652,9 +2652,9 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.0.tgz",
-			"integrity": "sha512-BOehWE7MgQ8W8Qn0CQnMtg2tHPHPulcS/5AVpFvs2KCK1ET+0WqZqPvnpRpFN81gYoFopdIEJX9Sgjw3ZBccPg==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
+			"integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
 			"dependencies": {
 				"core-js-pure": "^3.30.2",
 				"regenerator-runtime": "^0.14.0"
@@ -2677,15 +2677,15 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.25.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
-			"integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+			"integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.25.4",
-				"@babel/parser": "^7.25.4",
+				"@babel/generator": "^7.25.6",
+				"@babel/parser": "^7.25.6",
 				"@babel/template": "^7.25.0",
-				"@babel/types": "^7.25.4",
+				"@babel/types": "^7.25.6",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2694,9 +2694,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.25.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-			"integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+			"integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.24.8",
 				"@babel/helper-validator-identifier": "^7.24.7",
@@ -2985,9 +2985,9 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.8.tgz",
-			"integrity": "sha512-qKwC/M/nNNaKUBMQ0nuzm47b7ZYWQHN3pcXq4IIcoSBc2hOIrflAxJduIvvqmhoz3gR2TacTAs8vlsCVPkiEdQ==",
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+			"integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
 			}
@@ -3104,18 +3104,18 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "11.3.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.3.1.tgz",
-			"integrity": "sha512-yBWSBiagx3sQUezICkWQaJqbLyd0elPiFmJRtyhJe3iFXYW5mmv3TFj4jnum4hsK96MmylhkFf8mCYY32fdExA==",
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.3.3.tgz",
+			"integrity": "sha512-Hq5aGbX3a0PE0csxv0VnlDlN0dllDj0DObuitanMEqJGga3NA+kVng1mXg0O6qhpV1CMMHIu+VAYxNM3SoUlcg==",
 			"dependencies": {
 				"@babel/register": "^7.24.6",
 				"@natlibfi/issn-verify": "^1.0.4",
-				"@natlibfi/marc-record": "^8.1.3",
+				"@natlibfi/marc-record": "^9.0.1",
 				"@natlibfi/marc-record-validate": "^8.0.8",
 				"cld3-asm": "^3.1.1",
 				"clone": "^2.1.2",
 				"debug": "^4.3.4",
-				"isbn3": "^1.1.49",
+				"isbn3": "^1.1.52",
 				"iso9_1995": "^0.0.2",
 				"langs": "^2.0.0",
 				"node-fetch": "^2.7.0",
@@ -3128,18 +3128,6 @@
 			},
 			"peerDependencies": {
 				"@natlibfi/marc-record-validate": "^8.0.7"
-			}
-		},
-		"node_modules/@natlibfi/marc-record-validators-melinda/node_modules/@natlibfi/marc-record": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-8.1.3.tgz",
-			"integrity": "sha512-u2MU4n1Z6WblH3vSEKTUoBO/hUaD36ff/dWpzFukF6k0/wTzwbBKlonAP+xhPtak9f7UNv2mPQOSZ7XSbZwiYw==",
-			"dependencies": {
-				"debug": "^4.3.4",
-				"jsonschema": "^1.4.1"
-			},
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
@@ -3192,17 +3180,16 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.2.5.tgz",
-			"integrity": "sha512-+7c1Bz98OSfu8ZnJrt0H5ES0nlhvFuKWCW90YDOteQSW+DwfT+fGqq66WMOkPoLRJ5ezEOFuzggD80jjyAIvPA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.3.0.tgz",
+			"integrity": "sha512-KcfGy82Tjroaase9aRw18jAPtZGgp7IZD28R1ZRG8lXJtjHGc7csU3hCcE4za6p8YAjS9tUXawox2iqgczf93Q==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.0.0",
-				"@natlibfi/marc-record-merge": "^7.0.3",
-				"@natlibfi/marc-record-validate": "^8.0.8",
-				"@natlibfi/marc-record-validators-melinda": "^11.3.1",
-				"@natlibfi/melinda-commons": "^13.0.15",
+				"@natlibfi/marc-record": "^9.0.1",
+				"@natlibfi/marc-record-merge": "^7.0.5",
+				"@natlibfi/marc-record-validate": "^8.0.10",
+				"@natlibfi/marc-record-validators-melinda": "^11.3.3",
 				"debug": "^4.3.6",
-				"isbn3": "^1.1.51"
+				"isbn3": "^1.1.52"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3426,9 +3413,9 @@
 			}
 		},
 		"node_modules/@smithy/abort-controller/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/config-resolver": {
@@ -3448,24 +3435,26 @@
 			}
 		},
 		"node_modules/@smithy/config-resolver/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/core": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.3.2.tgz",
-			"integrity": "sha512-in5wwt6chDBcUv1Lw1+QzZxN9fBffi+qOixfb65yK4sDuKG7zAUO9HAFqmVzsZM3N+3tTyvZjtnDXePpvp007Q==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.0.tgz",
+			"integrity": "sha512-cHXq+FneIF/KJbt4q4pjN186+Jf4ZB0ZOqEaZMBhT79srEyGDDBV31NqBRBjazz8ppQ1bJbDJMY9ba5wKFV36w==",
 			"optional": true,
 			"dependencies": {
 				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.14",
+				"@smithy/middleware-retry": "^3.0.15",
 				"@smithy/middleware-serde": "^3.0.3",
 				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3473,9 +3462,9 @@
 			}
 		},
 		"node_modules/@smithy/core/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/credential-provider-imds": {
@@ -3495,9 +3484,9 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/fetch-http-handler": {
@@ -3514,9 +3503,9 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/hash-node": {
@@ -3535,9 +3524,9 @@
 			}
 		},
 		"node_modules/@smithy/hash-node/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/invalid-dependency": {
@@ -3551,9 +3540,9 @@
 			}
 		},
 		"node_modules/@smithy/invalid-dependency/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/is-array-buffer": {
@@ -3569,9 +3558,9 @@
 			}
 		},
 		"node_modules/@smithy/is-array-buffer/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/middleware-content-length": {
@@ -3589,9 +3578,9 @@
 			}
 		},
 		"node_modules/@smithy/middleware-content-length/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/middleware-endpoint": {
@@ -3613,21 +3602,21 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.14.tgz",
-			"integrity": "sha512-7ZaWZJOjUxa5hgmuMspyt8v/zVsh0GXYuF7OvCmdcbVa/xbnKQoYC+uYKunAqRGTkxjOyuOCw9rmFUFOqqC0eQ==",
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+			"integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
 			"optional": true,
 			"dependencies": {
 				"@smithy/node-config-provider": "^3.1.4",
 				"@smithy/protocol-http": "^4.1.0",
 				"@smithy/service-error-classification": "^3.0.3",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
 				"@smithy/util-middleware": "^3.0.3",
 				"@smithy/util-retry": "^3.0.3",
@@ -3639,9 +3628,9 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/middleware-serde": {
@@ -3658,9 +3647,9 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/middleware-stack": {
@@ -3677,9 +3666,9 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/node-config-provider": {
@@ -3698,9 +3687,9 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/node-http-handler": {
@@ -3720,9 +3709,9 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/property-provider": {
@@ -3739,9 +3728,9 @@
 			}
 		},
 		"node_modules/@smithy/property-provider/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/protocol-http": {
@@ -3758,9 +3747,9 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/querystring-builder": {
@@ -3778,9 +3767,9 @@
 			}
 		},
 		"node_modules/@smithy/querystring-builder/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/querystring-parser": {
@@ -3797,9 +3786,9 @@
 			}
 		},
 		"node_modules/@smithy/querystring-parser/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/service-error-classification": {
@@ -3828,9 +3817,9 @@
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/signature-v4": {
@@ -3853,15 +3842,15 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "3.1.12",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.12.tgz",
-			"integrity": "sha512-wtm8JtsycthkHy1YA4zjIh2thJgIQ9vGkoR639DBx5lLlLNU0v4GARpQZkr2WjXue74nZ7MiTSWfVrLkyD8RkA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+			"integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
 			"optional": true,
 			"dependencies": {
 				"@smithy/middleware-endpoint": "^3.1.0",
@@ -3876,9 +3865,9 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/types": {
@@ -3894,9 +3883,9 @@
 			}
 		},
 		"node_modules/@smithy/types/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/url-parser": {
@@ -3911,9 +3900,9 @@
 			}
 		},
 		"node_modules/@smithy/url-parser/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-base64": {
@@ -3931,9 +3920,9 @@
 			}
 		},
 		"node_modules/@smithy/util-base64/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-body-length-browser": {
@@ -3946,9 +3935,9 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-body-length-node": {
@@ -3964,9 +3953,9 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-node/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-buffer-from": {
@@ -3983,9 +3972,9 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-config-provider": {
@@ -4001,19 +3990,19 @@
 			}
 		},
 		"node_modules/@smithy/util-config-provider/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.14.tgz",
-			"integrity": "sha512-0iwTgKKmAIf+vFLV8fji21Jb2px11ktKVxbX6LIDPAUJyWQqGqBVfwba7xwa1f2FZUoolYQgLvxQEpJycXuQ5w==",
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+			"integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
 			"optional": true,
 			"dependencies": {
 				"@smithy/property-provider": "^3.1.3",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
@@ -4023,22 +4012,22 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.14.tgz",
-			"integrity": "sha512-e9uQarJKfXApkTMMruIdxHprhcXivH1flYCe8JRDTzkkLx8dA3V5J8GZlST9yfDiRWkJpZJlUXGN9Rc9Ade3OQ==",
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+			"integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
 			"optional": true,
 			"dependencies": {
 				"@smithy/config-resolver": "^3.0.5",
 				"@smithy/credential-provider-imds": "^3.2.0",
 				"@smithy/node-config-provider": "^3.1.4",
 				"@smithy/property-provider": "^3.1.3",
-				"@smithy/smithy-client": "^3.1.12",
+				"@smithy/smithy-client": "^3.2.0",
 				"@smithy/types": "^3.3.0",
 				"tslib": "^2.6.2"
 			},
@@ -4047,9 +4036,9 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-endpoints": {
@@ -4067,9 +4056,9 @@
 			}
 		},
 		"node_modules/@smithy/util-endpoints/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-hex-encoding": {
@@ -4085,9 +4074,9 @@
 			}
 		},
 		"node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-middleware": {
@@ -4104,9 +4093,9 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-retry": {
@@ -4124,9 +4113,9 @@
 			}
 		},
 		"node_modules/@smithy/util-retry/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-stream": {
@@ -4149,9 +4138,9 @@
 			}
 		},
 		"node_modules/@smithy/util-stream/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-uri-escape": {
@@ -4167,9 +4156,9 @@
 			}
 		},
 		"node_modules/@smithy/util-uri-escape/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@smithy/util-utf8": {
@@ -4186,9 +4175,9 @@
 			}
 		},
 		"node_modules/@smithy/util-utf8/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
 		"node_modules/@types/json-schema": {
@@ -4198,11 +4187,11 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "22.3.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
-			"integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
+			"version": "22.5.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
+			"integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
 			"dependencies": {
-				"undici-types": "~6.18.2"
+				"undici-types": "~6.19.2"
 			}
 		},
 		"node_modules/@types/semver": {
@@ -4646,9 +4635,9 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
@@ -4947,9 +4936,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001651",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-			"integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+			"version": "1.0.30001659",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001659.tgz",
+			"integrity": "sha512-Qxxyfv3RdHAfJcXelgf0hU4DFUVXBGTjqrBUZLUh8AtlGnsDo+CnncYtTd95+ZKfnANUOzxyIQCuU/UeBZBYoA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5160,9 +5149,9 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
 		},
 		"node_modules/core-js": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.0.tgz",
-			"integrity": "sha512-XPpwqEodRljce9KswjZShh95qJ1URisBeKCjUdq27YdenkslVe7OO0ZJhlYXAChW7OhXaRLl8AAba7IBfoIHug==",
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+			"integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -5171,9 +5160,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.0.tgz",
-			"integrity": "sha512-75LAicdLa4OJVwFxFbQR3NdnZjNgX6ILpVcVzcC4T2smerB5lELMrJQQQoWV6TiuC/vlaFqgU2tKQx9w5s0e0A==",
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+			"integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.3"
@@ -5184,9 +5173,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.0.tgz",
-			"integrity": "sha512-8balb/HAXo06aHP58mZMtXgD8vcnXz9tUDePgqBgJgKdmTlMt+jw3ujqniuBDQXMvTzxnMpxHFeuSM3g1jWQuQ==",
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
+			"integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -5282,11 +5271,11 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -5490,9 +5479,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.9",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.9.tgz",
-			"integrity": "sha512-HfkT8ndXR0SEkU8gBQQM3rz035bpE/hxkZ1YIt4KJPEFES68HfIU6LzKukH0H794Lm83WJtkSAMfEToxCs15VA=="
+			"version": "1.5.18",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.18.tgz",
+			"integrity": "sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -5665,9 +5654,9 @@
 			"dev": true
 		},
 		"node_modules/escalade": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -7170,9 +7159,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-			"integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+			"integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
 			"dev": true,
 			"dependencies": {
 				"hasown": "^2.0.2"
@@ -7604,9 +7593,9 @@
 			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
 		},
 		"node_modules/isbn3": {
-			"version": "1.1.51",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.51.tgz",
-			"integrity": "sha512-D5j+PyhE2MbBF5XpHNVY1AECgf6RzyfvM++io5nW/+NFv2hMwL3zH5J8keN1VhHGvcezp2+LaeM99wW+UtMjRg==",
+			"version": "1.1.52",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.52.tgz",
+			"integrity": "sha512-eXkto3ehvZcGB5mMpyrhVMM8lo6I4NhkCziOxyYNmVVOg4dveEQ5L5J6AxdZkD4iienVfELukrjeLdLOdyUkyg==",
 			"bin": {
 				"isbn": "bin/isbn",
 				"isbn-audit": "bin/isbn-audit",
@@ -8303,12 +8292,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/mocha/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
 		"node_modules/mocha/node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8412,13 +8395,13 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "8.5.3",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.5.3.tgz",
-			"integrity": "sha512-OubSDbsAclDFGHjV82MsKyIGQWFc42Ot1l+0dhRS6U9xODM7rm/ES/WpOQd8Ds9j0Mx8QzxZtrSCnBh6o9wUqw==",
+			"version": "8.6.1",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.6.1.tgz",
+			"integrity": "sha512-dppGcYqvsdg+VcnqXR5b467V4a+iNhmvkfYNpEPi6AjaUxnz6ioEDmrMLOi+sOWjvoHapuwPOigV4f2l7HC6ag==",
 			"dependencies": {
 				"bson": "^6.7.0",
 				"kareem": "2.6.3",
-				"mongodb": "6.7.0",
+				"mongodb": "6.8.0",
 				"mpath": "0.9.0",
 				"mquery": "5.0.0",
 				"ms": "2.1.3",
@@ -8449,9 +8432,9 @@
 			}
 		},
 		"node_modules/mongoose/node_modules/mongodb": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.7.0.tgz",
-			"integrity": "sha512-TMKyHdtMcO0fYBNORiYdmM25ijsHs+Njs963r4Tro4OQZzqYigAzYQouwWRg4OIaiLRUEGUh/1UAcH5lxdSLIA==",
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.8.0.tgz",
+			"integrity": "sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.1.5",
 				"bson": "^6.7.0",
@@ -8502,11 +8485,6 @@
 				"whatwg-url": "^13.0.0"
 			}
 		},
-		"node_modules/mongoose/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-		},
 		"node_modules/mongoose/node_modules/tr46": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
@@ -8550,9 +8528,9 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/nanoid": {
 			"version": "2.1.11",
@@ -8677,9 +8655,9 @@
 			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
 		},
 		"node_modules/nodemailer": {
-			"version": "6.9.14",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.14.tgz",
-			"integrity": "sha512-Dobp/ebDKBvz91sbtRKhcznLThrKxKt97GI2FAlAyy+fk19j73Uz3sBXolVtmcXjaorivqsbbbjDY+Jkt4/bQA==",
+			"version": "6.9.15",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.15.tgz",
+			"integrity": "sha512-AHf04ySLC6CIfuRtRiEYtGEXgRfa6INgWGluDhnxTZhHSKvrBu7lc1VVchQ0d8nPc4cFaZoPq8vkyNoZr0TpGQ==",
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -8760,9 +8738,9 @@
 			}
 		},
 		"node_modules/normalize-diacritics/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -9292,9 +9270,9 @@
 			}
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -9788,9 +9766,9 @@
 			}
 		},
 		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
 			"engines": {
 				"node": ">=10"
 			}
@@ -10510,9 +10488,9 @@
 			"integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
 		},
 		"node_modules/undici-types": {
-			"version": "6.18.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
-			"integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ=="
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.6.5-alpha.2",
+	"version": "3.6.5-alpha.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.6.5-alpha.2",
+			"version": "3.6.5-alpha.3",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.25.0",
@@ -18,7 +18,7 @@
 				"@natlibfi/melinda-marc-record-merge-reducers": "^2.2.5",
 				"@natlibfi/melinda-record-match-validator": "^2.2.3",
 				"@natlibfi/melinda-record-matching": "^4.3.3",
-				"@natlibfi/melinda-rest-api-commons": "^4.1.9",
+				"@natlibfi/melinda-rest-api-commons": "^4.1.10",
 				"@natlibfi/sru-client": "^6.0.14",
 				"debug": "^4.3.6",
 				"deep-eql": "^4.1.4",
@@ -989,9 +989,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
-			"integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+			"integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1044,11 +1044,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-			"integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+			"version": "7.25.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
+			"integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
 			"dependencies": {
-				"@babel/types": "^7.25.0",
+				"@babel/types": "^7.25.4",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
@@ -1098,9 +1098,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.0.tgz",
-			"integrity": "sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+			"integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
@@ -1108,7 +1108,7 @@
 				"@babel/helper-optimise-call-expression": "^7.24.7",
 				"@babel/helper-replace-supers": "^7.25.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-				"@babel/traverse": "^7.25.0",
+				"@babel/traverse": "^7.25.4",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1361,11 +1361,11 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.25.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-			"integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
+			"integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
 			"dependencies": {
-				"@babel/types": "^7.25.2"
+				"@babel/types": "^7.25.4"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1716,15 +1716,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.0.tgz",
-			"integrity": "sha512-uaIi2FdqzjpAMvVqvB51S42oC2JEVgh0LDsGfZVDysWE8LrJtQC2jvKmOqEYThKyB7bDEb7BP1GYWDm7tABA0Q==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.4.tgz",
+			"integrity": "sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/helper-remap-async-to-generator": "^7.25.0",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
-				"@babel/traverse": "^7.25.0"
+				"@babel/traverse": "^7.25.4"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1781,13 +1781,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
-			"integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.4.tgz",
+			"integrity": "sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-create-class-features-plugin": "^7.25.4",
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1814,16 +1814,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.0.tgz",
-			"integrity": "sha512-xyi6qjr/fYU304fiRwFbekzkqVJZ6A7hOjWZd+89FVcBqPV3S9Wuozz82xdpLspckeaafntbzglaW4pqpzvtSw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz",
+			"integrity": "sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-compilation-targets": "^7.24.8",
+				"@babel/helper-compilation-targets": "^7.25.2",
 				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/helper-replace-supers": "^7.25.0",
-				"@babel/traverse": "^7.25.0",
+				"@babel/traverse": "^7.25.4",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -2267,13 +2267,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz",
-			"integrity": "sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.4.tgz",
+			"integrity": "sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-create-class-features-plugin": "^7.25.4",
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2347,15 +2347,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.7.tgz",
-			"integrity": "sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.4.tgz",
+			"integrity": "sha512-8hsyG+KUYGY0coX6KUCDancA0Vw225KJ2HJO0yCNr1vq5r+lJTleDaJf0K7iOhjw4SWhu03TMBzYTJ9krmzULQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.8",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.1",
+				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"semver": "^6.3.1"
 			},
@@ -2490,13 +2490,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.7.tgz",
-			"integrity": "sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.4.tgz",
+			"integrity": "sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.2",
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2506,12 +2506,12 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.25.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.3.tgz",
-			"integrity": "sha512-QsYW7UeAaXvLPX9tdVliMJE7MD7M6MLYVTovRTIwhoYQVFHR1rM4wO8wqAezYi3/BpSD+NzVCZ69R6smWiIi8g==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.4.tgz",
+			"integrity": "sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.25.2",
+				"@babel/compat-data": "^7.25.4",
 				"@babel/helper-compilation-targets": "^7.25.2",
 				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/helper-validator-option": "^7.24.8",
@@ -2540,13 +2540,13 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.24.7",
-				"@babel/plugin-transform-async-generator-functions": "^7.25.0",
+				"@babel/plugin-transform-async-generator-functions": "^7.25.4",
 				"@babel/plugin-transform-async-to-generator": "^7.24.7",
 				"@babel/plugin-transform-block-scoped-functions": "^7.24.7",
 				"@babel/plugin-transform-block-scoping": "^7.25.0",
-				"@babel/plugin-transform-class-properties": "^7.24.7",
+				"@babel/plugin-transform-class-properties": "^7.25.4",
 				"@babel/plugin-transform-class-static-block": "^7.24.7",
-				"@babel/plugin-transform-classes": "^7.25.0",
+				"@babel/plugin-transform-classes": "^7.25.4",
 				"@babel/plugin-transform-computed-properties": "^7.24.7",
 				"@babel/plugin-transform-destructuring": "^7.24.8",
 				"@babel/plugin-transform-dotall-regex": "^7.24.7",
@@ -2574,7 +2574,7 @@
 				"@babel/plugin-transform-optional-catch-binding": "^7.24.7",
 				"@babel/plugin-transform-optional-chaining": "^7.24.8",
 				"@babel/plugin-transform-parameters": "^7.24.7",
-				"@babel/plugin-transform-private-methods": "^7.24.7",
+				"@babel/plugin-transform-private-methods": "^7.25.4",
 				"@babel/plugin-transform-private-property-in-object": "^7.24.7",
 				"@babel/plugin-transform-property-literals": "^7.24.7",
 				"@babel/plugin-transform-regenerator": "^7.24.7",
@@ -2587,10 +2587,10 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.24.7",
 				"@babel/plugin-transform-unicode-property-regex": "^7.24.7",
 				"@babel/plugin-transform-unicode-regex": "^7.24.7",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.24.7",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.25.4",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.4",
+				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"core-js-compat": "^3.37.1",
 				"semver": "^6.3.1"
@@ -2641,9 +2641,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-			"integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.4.tgz",
+			"integrity": "sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -2677,15 +2677,15 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.25.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
-			"integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
+			"integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.25.0",
-				"@babel/parser": "^7.25.3",
+				"@babel/generator": "^7.25.4",
+				"@babel/parser": "^7.25.4",
 				"@babel/template": "^7.25.0",
-				"@babel/types": "^7.25.2",
+				"@babel/types": "^7.25.4",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2694,9 +2694,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-			"integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+			"integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.24.8",
 				"@babel/helper-validator-identifier": "^7.24.7",
@@ -3166,18 +3166,18 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.16",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.16.tgz",
-			"integrity": "sha512-mxJEzDORt+Wx39jEh/0Hql3HDvYL5+URDB98XEmvTE6Wl79ZwScdEz10RMz+5FiMdpWl6RwyO3Zn/jGuwmxl9Q==",
+			"version": "13.0.17",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.17.tgz",
+			"integrity": "sha512-Jh2MfrSK/gEmnHkE8e96XvNHCGM1wEFKIKrfkhKNEqlWhTQssvsjLRkq9XABStebf99Jannji82dFXML4+BecA==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^9.0.1",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.12",
+				"@natlibfi/sru-client": "^6.0.14",
 				"debug": "^4.3.6",
 				"deep-eql": "^5.0.2",
 				"http-status": "^1.7.4",
 				"moment": "^2.30.1",
-				"nock": "^13.5.4"
+				"nock": "^13.5.5"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3256,9 +3256,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.9.tgz",
-			"integrity": "sha512-58yusIdTZrSLa9tM6Bsa1f9FrwkVJFlpLLWAxOdRlLfnpm+BBmam0dQYfDggypWHy+on+lFYALqcdTue73FJcQ==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.10.tgz",
+			"integrity": "sha512-kxeRIXFKipEsCm3K65bsy4Nd02BBwtlTKH9aqsJKZWbJjPzeUA+dq8kG9U2mzGq0taJjNFjA4b4z0Ynk6Ddrrg==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^9.0.1",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
@@ -8128,9 +8128,9 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -8590,9 +8590,9 @@
 			"dev": true
 		},
 		"node_modules/nock": {
-			"version": "13.5.4",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-			"integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+			"version": "13.5.5",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.5.tgz",
+			"integrity": "sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==",
 			"dependencies": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "3.6.5-alpha.3",
+	"version": "3.6.5-alpha.4",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -34,28 +34,28 @@
 		"dev": "NODE_ENV=development cross-env nodemon"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.25.0",
+		"@babel/runtime": "^7.25.6",
 		"@natlibfi/marc-record": "^9.0.1",
 		"@natlibfi/marc-record-merge": "^7.0.5",
 		"@natlibfi/marc-record-serializers": "^10.1.2",
 		"@natlibfi/melinda-backend-commons": "^2.3.1",
-		"@natlibfi/melinda-commons": "^13.0.16",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^2.2.5",
+		"@natlibfi/melinda-commons": "^13.0.17",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.0",
 		"@natlibfi/melinda-record-match-validator": "^2.2.3",
 		"@natlibfi/melinda-record-matching": "^4.3.3",
 		"@natlibfi/melinda-rest-api-commons": "^4.1.10",
 		"@natlibfi/sru-client": "^6.0.14",
-		"debug": "^4.3.6",
+		"debug": "^4.3.7",
 		"deep-eql": "^4.1.4",
 		"deep-object-diff": "^1.1.9",
 		"http-status": "^1.7.4"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.24.8",
+		"@babel/cli": "^7.25.6",
 		"@babel/core": "^7.25.2",
 		"@babel/node": "^7.25.0",
-		"@babel/plugin-transform-runtime": "^7.24.7",
-		"@babel/preset-env": "^7.25.3",
+		"@babel/plugin-transform-runtime": "^7.25.4",
+		"@babel/preset-env": "^7.25.4",
 		"@babel/register": "^7.24.6",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
 		"@natlibfi/fixugen": "^2.0.9",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "3.6.5-alpha.2",
+	"version": "3.6.5-alpha.3",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -43,7 +43,7 @@
 		"@natlibfi/melinda-marc-record-merge-reducers": "^2.2.5",
 		"@natlibfi/melinda-record-match-validator": "^2.2.3",
 		"@natlibfi/melinda-record-matching": "^4.3.3",
-		"@natlibfi/melinda-rest-api-commons": "^4.1.9",
+		"@natlibfi/melinda-rest-api-commons": "^4.1.10",
 		"@natlibfi/sru-client": "^6.0.14",
 		"debug": "^4.3.6",
 		"deep-eql": "^4.1.4",


### PR DESCRIPTION
* Bump the development-dependencies group with 2 updates (#442)

Bumps the development-dependencies group with 2 updates: [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-runtime) and [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env).

* Bump the production-dependencies group with 2 updates (#441)

Bumps the production-dependencies group with 2 updates: [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime) and [@natlibfi/melinda-commons](https://github.com/natlibfi/melinda-commons-js).

* Aut main webhooks (#444)

* Update deps

* 3.6.5-alpha.3