### PR TITLE
Dependency Update including [MELKEHITYS-3107]  (#496)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,32 +1,32 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.7.3",
+	"version": "3.7.4-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.7.3",
+			"version": "3.7.4-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.26.0",
 				"@natlibfi/marc-record": "^9.1.1",
-				"@natlibfi/marc-record-merge": "^7.0.6",
+				"@natlibfi/marc-record-merge": "^7.0.7",
 				"@natlibfi/marc-record-serializers": "^10.1.4",
-				"@natlibfi/melinda-backend-commons": "^2.3.5",
+				"@natlibfi/melinda-backend-commons": "^2.3.6",
 				"@natlibfi/melinda-commons": "^13.0.18",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.2",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.3",
 				"@natlibfi/melinda-record-match-validator": "^2.2.4",
 				"@natlibfi/melinda-record-matching": "^4.3.4",
 				"@natlibfi/melinda-rest-api-commons": "^4.2.2",
 				"@natlibfi/sru-client": "^6.0.16",
-				"debug": "^4.3.7",
+				"debug": "^4.4.0",
 				"deep-eql": "^4.1.4",
 				"deep-object-diff": "^1.1.9",
 				"http-status": "^1.8.1"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.25.9",
+				"@babel/cli": "^7.26.4",
 				"@babel/core": "^7.26.0",
 				"@babel/node": "^7.26.0",
 				"@babel/plugin-transform-runtime": "^7.25.9",
@@ -66,6 +66,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
 			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -239,51 +240,51 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.699.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.699.0.tgz",
-			"integrity": "sha512-9tFt+we6AIvj/f1+nrLHuCWcQmyfux5gcBSOy9d9+zIG56YxGEX7S9TaZnybogpVV8A0BYWml36WvIHS9QjIpA==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.709.0.tgz",
+			"integrity": "sha512-I5a8ilF+jKAz6fmOOuHy2UEcod9ikRGBjACcC6ayxs4z4VqTnWynD6ALKvtUR3lk1Ur6nzAG1tTm/qAYKKmyBg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.699.0",
-				"@aws-sdk/client-sts": "3.699.0",
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/credential-provider-node": "3.699.0",
-				"@aws-sdk/middleware-host-header": "3.696.0",
-				"@aws-sdk/middleware-logger": "3.696.0",
-				"@aws-sdk/middleware-recursion-detection": "3.696.0",
-				"@aws-sdk/middleware-user-agent": "3.696.0",
-				"@aws-sdk/region-config-resolver": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@aws-sdk/util-endpoints": "3.696.0",
-				"@aws-sdk/util-user-agent-browser": "3.696.0",
-				"@aws-sdk/util-user-agent-node": "3.696.0",
-				"@smithy/config-resolver": "^3.0.12",
-				"@smithy/core": "^2.5.3",
-				"@smithy/fetch-http-handler": "^4.1.1",
-				"@smithy/hash-node": "^3.0.10",
-				"@smithy/invalid-dependency": "^3.0.10",
-				"@smithy/middleware-content-length": "^3.0.12",
-				"@smithy/middleware-endpoint": "^3.2.3",
-				"@smithy/middleware-retry": "^3.0.27",
-				"@smithy/middleware-serde": "^3.0.10",
-				"@smithy/middleware-stack": "^3.0.10",
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/node-http-handler": "^3.3.1",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/smithy-client": "^3.4.4",
-				"@smithy/types": "^3.7.1",
-				"@smithy/url-parser": "^3.0.10",
+				"@aws-sdk/client-sso-oidc": "3.709.0",
+				"@aws-sdk/client-sts": "3.709.0",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/credential-provider-node": "3.709.0",
+				"@aws-sdk/middleware-host-header": "3.709.0",
+				"@aws-sdk/middleware-logger": "3.709.0",
+				"@aws-sdk/middleware-recursion-detection": "3.709.0",
+				"@aws-sdk/middleware-user-agent": "3.709.0",
+				"@aws-sdk/region-config-resolver": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@aws-sdk/util-endpoints": "3.709.0",
+				"@aws-sdk/util-user-agent-browser": "3.709.0",
+				"@aws-sdk/util-user-agent-node": "3.709.0",
+				"@smithy/config-resolver": "^3.0.13",
+				"@smithy/core": "^2.5.5",
+				"@smithy/fetch-http-handler": "^4.1.2",
+				"@smithy/hash-node": "^3.0.11",
+				"@smithy/invalid-dependency": "^3.0.11",
+				"@smithy/middleware-content-length": "^3.0.13",
+				"@smithy/middleware-endpoint": "^3.2.5",
+				"@smithy/middleware-retry": "^3.0.30",
+				"@smithy/middleware-serde": "^3.0.11",
+				"@smithy/middleware-stack": "^3.0.11",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/node-http-handler": "^3.3.2",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/smithy-client": "^3.5.0",
+				"@smithy/types": "^3.7.2",
+				"@smithy/url-parser": "^3.0.11",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.27",
-				"@smithy/util-defaults-mode-node": "^3.0.27",
-				"@smithy/util-endpoints": "^2.1.6",
-				"@smithy/util-middleware": "^3.0.10",
-				"@smithy/util-retry": "^3.0.10",
+				"@smithy/util-defaults-mode-browser": "^3.0.30",
+				"@smithy/util-defaults-mode-node": "^3.0.30",
+				"@smithy/util-endpoints": "^2.1.7",
+				"@smithy/util-middleware": "^3.0.11",
+				"@smithy/util-retry": "^3.0.11",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -299,48 +300,48 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.696.0.tgz",
-			"integrity": "sha512-q5TTkd08JS0DOkHfUL853tuArf7NrPeqoS5UOvqJho8ibV9Ak/a/HO4kNvy9Nj3cib/toHYHsQIEtecUPSUUrQ==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.709.0.tgz",
+			"integrity": "sha512-Qxeo8cN0jNy6Wnbqq4wucffAGJM6sJjofoTgNtPA6cC7sPYx7aYC6OAAAo6NaMRY+WywOKdS9Wgjx2QYRxKx7w==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/middleware-host-header": "3.696.0",
-				"@aws-sdk/middleware-logger": "3.696.0",
-				"@aws-sdk/middleware-recursion-detection": "3.696.0",
-				"@aws-sdk/middleware-user-agent": "3.696.0",
-				"@aws-sdk/region-config-resolver": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@aws-sdk/util-endpoints": "3.696.0",
-				"@aws-sdk/util-user-agent-browser": "3.696.0",
-				"@aws-sdk/util-user-agent-node": "3.696.0",
-				"@smithy/config-resolver": "^3.0.12",
-				"@smithy/core": "^2.5.3",
-				"@smithy/fetch-http-handler": "^4.1.1",
-				"@smithy/hash-node": "^3.0.10",
-				"@smithy/invalid-dependency": "^3.0.10",
-				"@smithy/middleware-content-length": "^3.0.12",
-				"@smithy/middleware-endpoint": "^3.2.3",
-				"@smithy/middleware-retry": "^3.0.27",
-				"@smithy/middleware-serde": "^3.0.10",
-				"@smithy/middleware-stack": "^3.0.10",
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/node-http-handler": "^3.3.1",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/smithy-client": "^3.4.4",
-				"@smithy/types": "^3.7.1",
-				"@smithy/url-parser": "^3.0.10",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/middleware-host-header": "3.709.0",
+				"@aws-sdk/middleware-logger": "3.709.0",
+				"@aws-sdk/middleware-recursion-detection": "3.709.0",
+				"@aws-sdk/middleware-user-agent": "3.709.0",
+				"@aws-sdk/region-config-resolver": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@aws-sdk/util-endpoints": "3.709.0",
+				"@aws-sdk/util-user-agent-browser": "3.709.0",
+				"@aws-sdk/util-user-agent-node": "3.709.0",
+				"@smithy/config-resolver": "^3.0.13",
+				"@smithy/core": "^2.5.5",
+				"@smithy/fetch-http-handler": "^4.1.2",
+				"@smithy/hash-node": "^3.0.11",
+				"@smithy/invalid-dependency": "^3.0.11",
+				"@smithy/middleware-content-length": "^3.0.13",
+				"@smithy/middleware-endpoint": "^3.2.5",
+				"@smithy/middleware-retry": "^3.0.30",
+				"@smithy/middleware-serde": "^3.0.11",
+				"@smithy/middleware-stack": "^3.0.11",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/node-http-handler": "^3.3.2",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/smithy-client": "^3.5.0",
+				"@smithy/types": "^3.7.2",
+				"@smithy/url-parser": "^3.0.11",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.27",
-				"@smithy/util-defaults-mode-node": "^3.0.27",
-				"@smithy/util-endpoints": "^2.1.6",
-				"@smithy/util-middleware": "^3.0.10",
-				"@smithy/util-retry": "^3.0.10",
+				"@smithy/util-defaults-mode-browser": "^3.0.30",
+				"@smithy/util-defaults-mode-node": "^3.0.30",
+				"@smithy/util-endpoints": "^2.1.7",
+				"@smithy/util-middleware": "^3.0.11",
+				"@smithy/util-retry": "^3.0.11",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -349,49 +350,49 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.699.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.699.0.tgz",
-			"integrity": "sha512-u8a1GorY5D1l+4FQAf4XBUC1T10/t7neuwT21r0ymrtMFSK2a9QqVHKMoLkvavAwyhJnARSBM9/UQC797PFOFw==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.709.0.tgz",
+			"integrity": "sha512-1w6egz17QQy661lNCRmZZlqIANEbD6g2VFAQIJbVwSiu7brg+GUns+mT1eLLLHAMQc1sL0Ds8/ybSK2SrgGgIA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/credential-provider-node": "3.699.0",
-				"@aws-sdk/middleware-host-header": "3.696.0",
-				"@aws-sdk/middleware-logger": "3.696.0",
-				"@aws-sdk/middleware-recursion-detection": "3.696.0",
-				"@aws-sdk/middleware-user-agent": "3.696.0",
-				"@aws-sdk/region-config-resolver": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@aws-sdk/util-endpoints": "3.696.0",
-				"@aws-sdk/util-user-agent-browser": "3.696.0",
-				"@aws-sdk/util-user-agent-node": "3.696.0",
-				"@smithy/config-resolver": "^3.0.12",
-				"@smithy/core": "^2.5.3",
-				"@smithy/fetch-http-handler": "^4.1.1",
-				"@smithy/hash-node": "^3.0.10",
-				"@smithy/invalid-dependency": "^3.0.10",
-				"@smithy/middleware-content-length": "^3.0.12",
-				"@smithy/middleware-endpoint": "^3.2.3",
-				"@smithy/middleware-retry": "^3.0.27",
-				"@smithy/middleware-serde": "^3.0.10",
-				"@smithy/middleware-stack": "^3.0.10",
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/node-http-handler": "^3.3.1",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/smithy-client": "^3.4.4",
-				"@smithy/types": "^3.7.1",
-				"@smithy/url-parser": "^3.0.10",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/credential-provider-node": "3.709.0",
+				"@aws-sdk/middleware-host-header": "3.709.0",
+				"@aws-sdk/middleware-logger": "3.709.0",
+				"@aws-sdk/middleware-recursion-detection": "3.709.0",
+				"@aws-sdk/middleware-user-agent": "3.709.0",
+				"@aws-sdk/region-config-resolver": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@aws-sdk/util-endpoints": "3.709.0",
+				"@aws-sdk/util-user-agent-browser": "3.709.0",
+				"@aws-sdk/util-user-agent-node": "3.709.0",
+				"@smithy/config-resolver": "^3.0.13",
+				"@smithy/core": "^2.5.5",
+				"@smithy/fetch-http-handler": "^4.1.2",
+				"@smithy/hash-node": "^3.0.11",
+				"@smithy/invalid-dependency": "^3.0.11",
+				"@smithy/middleware-content-length": "^3.0.13",
+				"@smithy/middleware-endpoint": "^3.2.5",
+				"@smithy/middleware-retry": "^3.0.30",
+				"@smithy/middleware-serde": "^3.0.11",
+				"@smithy/middleware-stack": "^3.0.11",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/node-http-handler": "^3.3.2",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/smithy-client": "^3.5.0",
+				"@smithy/types": "^3.7.2",
+				"@smithy/url-parser": "^3.0.11",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.27",
-				"@smithy/util-defaults-mode-node": "^3.0.27",
-				"@smithy/util-endpoints": "^2.1.6",
-				"@smithy/util-middleware": "^3.0.10",
-				"@smithy/util-retry": "^3.0.10",
+				"@smithy/util-defaults-mode-browser": "^3.0.30",
+				"@smithy/util-defaults-mode-node": "^3.0.30",
+				"@smithy/util-endpoints": "^2.1.7",
+				"@smithy/util-middleware": "^3.0.11",
+				"@smithy/util-retry": "^3.0.11",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -399,7 +400,7 @@
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.699.0"
+				"@aws-sdk/client-sts": "^3.709.0"
 			}
 		},
 		"node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
@@ -417,50 +418,50 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-sts": {
-			"version": "3.699.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.699.0.tgz",
-			"integrity": "sha512-++lsn4x2YXsZPIzFVwv3fSUVM55ZT0WRFmPeNilYIhZClxHLmVAWKH4I55cY9ry60/aTKYjzOXkWwyBKGsGvQg==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.709.0.tgz",
+			"integrity": "sha512-cBAvlPg6yslXNL385UUGFPw+XY+lA9BzioNdIFkMo3fEUlTShogTtiWz4LsyLHoN6LhKojssP9DSmmWKWjCZIw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.699.0",
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/credential-provider-node": "3.699.0",
-				"@aws-sdk/middleware-host-header": "3.696.0",
-				"@aws-sdk/middleware-logger": "3.696.0",
-				"@aws-sdk/middleware-recursion-detection": "3.696.0",
-				"@aws-sdk/middleware-user-agent": "3.696.0",
-				"@aws-sdk/region-config-resolver": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@aws-sdk/util-endpoints": "3.696.0",
-				"@aws-sdk/util-user-agent-browser": "3.696.0",
-				"@aws-sdk/util-user-agent-node": "3.696.0",
-				"@smithy/config-resolver": "^3.0.12",
-				"@smithy/core": "^2.5.3",
-				"@smithy/fetch-http-handler": "^4.1.1",
-				"@smithy/hash-node": "^3.0.10",
-				"@smithy/invalid-dependency": "^3.0.10",
-				"@smithy/middleware-content-length": "^3.0.12",
-				"@smithy/middleware-endpoint": "^3.2.3",
-				"@smithy/middleware-retry": "^3.0.27",
-				"@smithy/middleware-serde": "^3.0.10",
-				"@smithy/middleware-stack": "^3.0.10",
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/node-http-handler": "^3.3.1",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/smithy-client": "^3.4.4",
-				"@smithy/types": "^3.7.1",
-				"@smithy/url-parser": "^3.0.10",
+				"@aws-sdk/client-sso-oidc": "3.709.0",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/credential-provider-node": "3.709.0",
+				"@aws-sdk/middleware-host-header": "3.709.0",
+				"@aws-sdk/middleware-logger": "3.709.0",
+				"@aws-sdk/middleware-recursion-detection": "3.709.0",
+				"@aws-sdk/middleware-user-agent": "3.709.0",
+				"@aws-sdk/region-config-resolver": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@aws-sdk/util-endpoints": "3.709.0",
+				"@aws-sdk/util-user-agent-browser": "3.709.0",
+				"@aws-sdk/util-user-agent-node": "3.709.0",
+				"@smithy/config-resolver": "^3.0.13",
+				"@smithy/core": "^2.5.5",
+				"@smithy/fetch-http-handler": "^4.1.2",
+				"@smithy/hash-node": "^3.0.11",
+				"@smithy/invalid-dependency": "^3.0.11",
+				"@smithy/middleware-content-length": "^3.0.13",
+				"@smithy/middleware-endpoint": "^3.2.5",
+				"@smithy/middleware-retry": "^3.0.30",
+				"@smithy/middleware-serde": "^3.0.11",
+				"@smithy/middleware-stack": "^3.0.11",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/node-http-handler": "^3.3.2",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/smithy-client": "^3.5.0",
+				"@smithy/types": "^3.7.2",
+				"@smithy/url-parser": "^3.0.11",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.27",
-				"@smithy/util-defaults-mode-node": "^3.0.27",
-				"@smithy/util-endpoints": "^2.1.6",
-				"@smithy/util-middleware": "^3.0.10",
-				"@smithy/util-retry": "^3.0.10",
+				"@smithy/util-defaults-mode-browser": "^3.0.30",
+				"@smithy/util-defaults-mode-node": "^3.0.30",
+				"@smithy/util-endpoints": "^2.1.7",
+				"@smithy/util-middleware": "^3.0.11",
+				"@smithy/util-retry": "^3.0.11",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -476,21 +477,21 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.696.0.tgz",
-			"integrity": "sha512-3c9III1k03DgvRZWg8vhVmfIXPG6hAciN9MzQTzqGngzWAELZF/WONRTRQuDFixVtarQatmLHYVw/atGeA2Byw==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.709.0.tgz",
+			"integrity": "sha512-7kuSpzdOTAE026j85wq/fN9UDZ70n0OHw81vFqMWwlEFtm5IQ/MRCLKcC4HkXxTdfy1PqFlmoXxWqeBa15tujw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/core": "^2.5.3",
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/signature-v4": "^4.2.2",
-				"@smithy/smithy-client": "^3.4.4",
-				"@smithy/types": "^3.7.1",
-				"@smithy/util-middleware": "^3.0.10",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/core": "^2.5.5",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/signature-v4": "^4.2.4",
+				"@smithy/smithy-client": "^3.5.0",
+				"@smithy/types": "^3.7.2",
+				"@smithy/util-middleware": "^3.0.11",
 				"fast-xml-parser": "4.4.1",
 				"tslib": "^2.6.2"
 			},
@@ -506,16 +507,16 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.699.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.699.0.tgz",
-			"integrity": "sha512-iuaTnudaBfEET+o444sDwf71Awe6UiZfH+ipUPmswAi2jZDwdFF1nxMKDEKL8/LV5WpXsdKSfwgS0RQeupURew==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.709.0.tgz",
+			"integrity": "sha512-WLzDcYo7pob8fPeeOhgVqYuV21uUKWb1RobITQzZhv0ZSToIl1KjuyRQsznC23Sot9CFl+0V2QLFFNwRiIuH7w==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.699.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/client-cognito-identity": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -530,16 +531,16 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.696.0.tgz",
-			"integrity": "sha512-T9iMFnJL7YTlESLpVFT3fg1Lkb1lD+oiaIC8KMpepb01gDUBIpj9+Y+pA/cgRWW0yRxmkDXNazAE2qQTVFGJzA==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.709.0.tgz",
+			"integrity": "sha512-ZMAp9LSikvHDFVa84dKpQmow6wsg956Um20cKuioPpX2GGreJFur7oduD+tRJT6FtIOHn+64YH+0MwiXLhsaIQ==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -554,21 +555,21 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.696.0.tgz",
-			"integrity": "sha512-GV6EbvPi2eq1+WgY/o2RFA3P7HGmnkIzCNmhwtALFlqMroLYWKE7PSeHw66Uh1dFQeVESn0/+hiUNhu1mB0emA==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.709.0.tgz",
+			"integrity": "sha512-lIS7XLwCOyJnLD70f+VIRr8DNV1HPQe9oN6aguYrhoczqz7vDiVZLe3lh714cJqq9rdxzFypK5DqKHmcscMEPQ==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/fetch-http-handler": "^4.1.1",
-				"@smithy/node-http-handler": "^3.3.1",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/smithy-client": "^3.4.4",
-				"@smithy/types": "^3.7.1",
-				"@smithy/util-stream": "^3.3.1",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/fetch-http-handler": "^4.1.2",
+				"@smithy/node-http-handler": "^3.3.2",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/smithy-client": "^3.5.0",
+				"@smithy/types": "^3.7.2",
+				"@smithy/util-stream": "^3.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -583,30 +584,30 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.699.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.699.0.tgz",
-			"integrity": "sha512-dXmCqjJnKmG37Q+nLjPVu22mNkrGHY8hYoOt3Jo9R2zr5MYV7s/NHsCHr+7E+BZ+tfZYLRPeB1wkpTeHiEcdRw==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.709.0.tgz",
+			"integrity": "sha512-qCF8IIGcPoUp+Ib3ANhbF5gElxFd+kIrtv2/1tKdvhudMANstQbMiWV0LTH47ZZR6c3as4iSrm09NZnpEoD/pA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/credential-provider-env": "3.696.0",
-				"@aws-sdk/credential-provider-http": "3.696.0",
-				"@aws-sdk/credential-provider-process": "3.696.0",
-				"@aws-sdk/credential-provider-sso": "3.699.0",
-				"@aws-sdk/credential-provider-web-identity": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/credential-provider-imds": "^3.2.6",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/shared-ini-file-loader": "^3.1.10",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/credential-provider-env": "3.709.0",
+				"@aws-sdk/credential-provider-http": "3.709.0",
+				"@aws-sdk/credential-provider-process": "3.709.0",
+				"@aws-sdk/credential-provider-sso": "3.709.0",
+				"@aws-sdk/credential-provider-web-identity": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/credential-provider-imds": "^3.2.8",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/shared-ini-file-loader": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.699.0"
+				"@aws-sdk/client-sts": "^3.709.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
@@ -617,23 +618,23 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.699.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.699.0.tgz",
-			"integrity": "sha512-MmEmNDo1bBtTgRmdNfdQksXu4uXe66s0p1hi1YPrn1h59Q605eq/xiWbGL6/3KdkViH6eGUuABeV2ODld86ylg==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.709.0.tgz",
+			"integrity": "sha512-4HRX9KYWPSjO5O/Vg03YAsebKpvTjTvpK1n7zHYBmlLMBLxUrVsL1nNKKC5p2/7OW3RL8XR1ki3QkoV7kGRxUQ==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.696.0",
-				"@aws-sdk/credential-provider-http": "3.696.0",
-				"@aws-sdk/credential-provider-ini": "3.699.0",
-				"@aws-sdk/credential-provider-process": "3.696.0",
-				"@aws-sdk/credential-provider-sso": "3.699.0",
-				"@aws-sdk/credential-provider-web-identity": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/credential-provider-imds": "^3.2.6",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/shared-ini-file-loader": "^3.1.10",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/credential-provider-env": "3.709.0",
+				"@aws-sdk/credential-provider-http": "3.709.0",
+				"@aws-sdk/credential-provider-ini": "3.709.0",
+				"@aws-sdk/credential-provider-process": "3.709.0",
+				"@aws-sdk/credential-provider-sso": "3.709.0",
+				"@aws-sdk/credential-provider-web-identity": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/credential-provider-imds": "^3.2.8",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/shared-ini-file-loader": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -648,17 +649,17 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.696.0.tgz",
-			"integrity": "sha512-mL1RcFDe9sfmyU5K1nuFkO8UiJXXxLX4JO1gVaDIOvPqwStpUAwi3A1BoeZhWZZNQsiKI810RnYGo0E0WB/hUA==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.709.0.tgz",
+			"integrity": "sha512-IAC+jPlGQII6jhIylHOwh3RgSobqlgL59nw2qYTURr8hMCI0Z1p5y2ee646HTVt4WeCYyzUAXfxr6YI/Vitv+Q==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/shared-ini-file-loader": "^3.1.10",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/shared-ini-file-loader": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -673,19 +674,19 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.699.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.699.0.tgz",
-			"integrity": "sha512-Ekp2cZG4pl9D8+uKWm4qO1xcm8/MeiI8f+dnlZm8aQzizeC+aXYy9GyoclSf6daK8KfRPiRfM7ZHBBL5dAfdMA==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.709.0.tgz",
+			"integrity": "sha512-rYdTDOxazS2GdGScelsRK5CAkktRLCCdRjlwXaxrcW57j749hEqxcF5uTv9RD6WBwInfedcSywErNZB+hylQlg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.696.0",
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/token-providers": "3.699.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/shared-ini-file-loader": "^3.1.10",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/client-sso": "3.709.0",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/token-providers": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/shared-ini-file-loader": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -700,23 +701,23 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.696.0.tgz",
-			"integrity": "sha512-XJ/CVlWChM0VCoc259vWguFUjJDn/QwDqHwbx+K9cg3v6yrqXfK5ai+p/6lx0nQpnk4JzPVeYYxWRpaTsGC9rg==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.709.0.tgz",
+			"integrity": "sha512-2lbDfE0IQ6gma/7BB2JpkjW5G0wGe4AS0x80oybYAYYviJmUtIR3Cn2pXun6bnAWElt4wYKl4su7oC36rs5rNA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.696.0"
+				"@aws-sdk/client-sts": "^3.709.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
@@ -727,28 +728,28 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.699.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.699.0.tgz",
-			"integrity": "sha512-jBjOntl9zN9Nvb0jmbMGRbiTzemDz64ij7W6BDavxBJRZpRoNeN0QCz6RolkCyXnyUJjo5mF2unY2wnv00A+LQ==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.709.0.tgz",
+			"integrity": "sha512-v1OfAWhYhAz7XPtjWlQ3jDLZHCpuNrLP2bRWTEjRty8yZLN92ANehincULUGvUNszFO8rfpq2g4dmtk8XmqTzA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.699.0",
-				"@aws-sdk/client-sso": "3.696.0",
-				"@aws-sdk/client-sts": "3.699.0",
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.699.0",
-				"@aws-sdk/credential-provider-env": "3.696.0",
-				"@aws-sdk/credential-provider-http": "3.696.0",
-				"@aws-sdk/credential-provider-ini": "3.699.0",
-				"@aws-sdk/credential-provider-node": "3.699.0",
-				"@aws-sdk/credential-provider-process": "3.696.0",
-				"@aws-sdk/credential-provider-sso": "3.699.0",
-				"@aws-sdk/credential-provider-web-identity": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/credential-provider-imds": "^3.2.6",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/client-cognito-identity": "3.709.0",
+				"@aws-sdk/client-sso": "3.709.0",
+				"@aws-sdk/client-sts": "3.709.0",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.709.0",
+				"@aws-sdk/credential-provider-env": "3.709.0",
+				"@aws-sdk/credential-provider-http": "3.709.0",
+				"@aws-sdk/credential-provider-ini": "3.709.0",
+				"@aws-sdk/credential-provider-node": "3.709.0",
+				"@aws-sdk/credential-provider-process": "3.709.0",
+				"@aws-sdk/credential-provider-sso": "3.709.0",
+				"@aws-sdk/credential-provider-web-identity": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/credential-provider-imds": "^3.2.8",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -763,15 +764,15 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.696.0.tgz",
-			"integrity": "sha512-zELJp9Ta2zkX7ELggMN9qMCgekqZhFC5V2rOr4hJDEb/Tte7gpfKSObAnw/3AYiVqt36sjHKfdkoTsuwGdEoDg==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.709.0.tgz",
+			"integrity": "sha512-8gQYCYAaIw4lOCd5WYdf15Y/61MgRsAnrb2eiTl+icMlUOOzl8aOl5iDwm/Idp0oHZTflwxM4XSvGXO83PRWcw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -786,14 +787,14 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.696.0.tgz",
-			"integrity": "sha512-KhkHt+8AjCxcR/5Zp3++YPJPpFQzxpr+jmONiT/Jw2yqnSngZ0Yspm5wGoRx2hS1HJbyZNuaOWEGuJoxLeBKfA==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.709.0.tgz",
+			"integrity": "sha512-jDoGSccXv9zebnpUoisjWd5u5ZPIalrmm6TjvPzZ8UqzQt3Beiz0tnQwmxQD6KRc7ADweWP5Ntiqzbw9xpVajg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -808,15 +809,15 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.696.0.tgz",
-			"integrity": "sha512-si/maV3Z0hH7qa99f9ru2xpS5HlfSVcasRlNUXKSDm611i7jFMWwGNLUOXFAOLhXotPX5G3Z6BLwL34oDeBMug==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.709.0.tgz",
+			"integrity": "sha512-PObL/wLr4lkfbQ0yXUWaoCWu/jcwfwZzCjsUiXW/H6hW9b/00enZxmx7OhtJYaR6xmh/Lcx5wbhIoDCbzdv0tw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -831,18 +832,18 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.696.0.tgz",
-			"integrity": "sha512-Lvyj8CTyxrHI6GHd2YVZKIRI5Fmnugt3cpJo0VrKKEgK5zMySwEZ1n4dqPK6czYRWKd5+WnYHYAuU+Wdk6Jsjw==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.709.0.tgz",
+			"integrity": "sha512-ooc9ZJvgkjPhi9q05XwSfNTXkEBEIfL4hleo5rQBKwHG3aTHvwOM7LLzhdX56QZVa6sorPBp6fwULuRDSqiQHw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@aws-sdk/util-endpoints": "3.696.0",
-				"@smithy/core": "^2.5.3",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/core": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@aws-sdk/util-endpoints": "3.709.0",
+				"@smithy/core": "^2.5.5",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -857,17 +858,17 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.696.0.tgz",
-			"integrity": "sha512-7EuH142lBXjI8yH6dVS/CZeiK/WZsmb/8zP6bQbVYpMrppSTgB3MzZZdxVZGzL5r8zPQOU10wLC4kIMy0qdBVQ==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.709.0.tgz",
+			"integrity": "sha512-/NoCAMEVKAg3kBKOrNtgOfL+ECt6nrl+L7q2SyYmrcY4tVCmwuECVqewQaHc03fTnJijfKLccw0Fj+6wOCnB6w==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"@smithy/util-config-provider": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.10",
+				"@smithy/util-middleware": "^3.0.11",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -882,23 +883,23 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.699.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.699.0.tgz",
-			"integrity": "sha512-kuiEW9DWs7fNos/SM+y58HCPhcIzm1nEZLhe2/7/6+TvAYLuEWURYsbK48gzsxXlaJ2k/jGY3nIsA7RptbMOwA==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.709.0.tgz",
+			"integrity": "sha512-q5Ar6k71nci43IbULFgC8a89d/3EHpmd7HvBzqVGRcHnoPwh8eZDBfbBXKH83NGwcS1qPSRYiDbVfeWPm4/1jA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/property-provider": "^3.1.9",
-				"@smithy/shared-ini-file-loader": "^3.1.10",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/shared-ini-file-loader": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sso-oidc": "^3.699.0"
+				"@aws-sdk/client-sso-oidc": "^3.709.0"
 			}
 		},
 		"node_modules/@aws-sdk/token-providers/node_modules/tslib": {
@@ -909,13 +910,13 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.696.0.tgz",
-			"integrity": "sha512-9rTvUJIAj5d3//U5FDPWGJ1nFJLuWb30vugGOrWk7aNZ6y9tuA3PI7Cc9dP8WEXKVyK1vuuk8rSFP2iqXnlgrw==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.709.0.tgz",
+			"integrity": "sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -930,15 +931,15 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.696.0.tgz",
-			"integrity": "sha512-T5s0IlBVX+gkb9g/I6CLt4yAZVzMSiGnbUqWihWsHvQR1WOoIcndQy/Oz/IJXT9T2ipoy7a80gzV6a5mglrioA==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.709.0.tgz",
+			"integrity": "sha512-Mbc7AtL5WGCTKC16IGeUTz+sjpC3ptBda2t0CcK0kMVw3THDdcSq6ZlNKO747cNqdbwUvW34oHteUiHv4/z88Q==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/types": "^3.7.1",
-				"@smithy/util-endpoints": "^2.1.6",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/types": "^3.7.2",
+				"@smithy/util-endpoints": "^2.1.7",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -973,14 +974,14 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.696.0.tgz",
-			"integrity": "sha512-Z5rVNDdmPOe6ELoM5AhF/ja5tSjbe6ctSctDPb0JdDf4dT0v2MfwhJKzXju2RzX8Es/77Glh7MlaXLE0kCB9+Q==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.709.0.tgz",
+			"integrity": "sha512-/rL2GasJzdTWUURCQKFldw2wqBtY4k4kCiA2tVZSKg3y4Ey7zO34SW8ebaeCE2/xoWOyLR2/etdKyphoo4Zrtg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/types": "^3.7.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
@@ -993,16 +994,16 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.696.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.696.0.tgz",
-			"integrity": "sha512-KhKqcfyXIB0SCCt+qsu4eJjsfiOrNzK5dCV7RAW2YIpp+msxGUUX0NdRE9rkzjiv+3EMktgJm3eEIS+yxtlVdQ==",
+			"version": "3.709.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.709.0.tgz",
+			"integrity": "sha512-trBfzSCVWy7ILgqhEXgiuM7hfRCw4F4a8IK90tjk9YL0jgoJ6eJuOp7+DfCtHJaygoBxD3cdMFkOu+lluFmGBA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "3.696.0",
-				"@aws-sdk/types": "3.696.0",
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/types": "^3.7.1",
+				"@aws-sdk/middleware-user-agent": "3.709.0",
+				"@aws-sdk/types": "3.709.0",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1058,6 +1059,7 @@
 			"version": "7.26.2",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
 			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.25.9",
@@ -1072,6 +1074,7 @@
 			"version": "7.26.3",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
 			"integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -1081,6 +1084,7 @@
 			"version": "7.26.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
 			"integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
@@ -1130,6 +1134,7 @@
 			"version": "7.26.3",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
 			"integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.26.3",
@@ -1159,6 +1164,7 @@
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
 			"integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/compat-data": "^7.25.9",
@@ -1246,6 +1252,7 @@
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
 			"integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/traverse": "^7.25.9",
@@ -1259,6 +1266,7 @@
 			"version": "7.26.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
 			"integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.25.9",
@@ -1349,6 +1357,7 @@
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
 			"integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -1358,6 +1367,7 @@
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
 			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -1367,6 +1377,7 @@
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
 			"integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -1391,6 +1402,7 @@
 			"version": "7.26.0",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
 			"integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.25.9",
@@ -1428,6 +1440,7 @@
 			"version": "7.26.3",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
 			"integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.26.3"
@@ -2546,6 +2559,7 @@
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.25.9.tgz",
 			"integrity": "sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"clone-deep": "^4.0.1",
@@ -2590,6 +2604,7 @@
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
 			"integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.25.9",
@@ -2604,6 +2619,7 @@
 			"version": "7.26.4",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
 			"integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
@@ -2622,6 +2638,7 @@
 			"version": "7.26.3",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
 			"integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.25.9",
@@ -2993,9 +3010,10 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
@@ -3010,6 +3028,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -3019,6 +3038,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
 			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -3028,12 +3048,14 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
 			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
 			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -3157,20 +3179,19 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "11.4.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.4.3.tgz",
-			"integrity": "sha512-P5J1fcr0cCgALxtvT40rdkMSjNz8phIayGlmlMnZrfEgUN1PK2TY1FQKiKJ5Kai5cvQ48k8eTTQ9Mi1FGgMcOQ==",
+			"version": "11.4.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.4.6.tgz",
+			"integrity": "sha512-C632RI/nlBoEecOQdNLa9M1reJ7vPpPQArdP9CFgRVd/QtcQckHt+FYBa3bk6kZhLxvd065JDJtTt7oLsrl+qQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/register": "^7.25.9",
 				"@natlibfi/issn-verify": "^1.0.4",
 				"@natlibfi/marc-record": "^9.1.1",
 				"@natlibfi/marc-record-validate": "^8.0.12",
-				"@natlibfi/sfs-4900": "^1.1.0",
+				"@natlibfi/sfs-4900": "git+https://github.com/NatLibFi/sfs-4900.git",
 				"cld3-asm": "^4.0.0",
 				"clone": "^2.1.2",
-				"debug": "^4.3.7",
-				"isbn3": "^1.2.3",
+				"debug": "^4.4.0",
+				"isbn3": "^1.2.4",
 				"iso9_1995": "^0.0.2",
 				"langs": "^2.0.0",
 				"node-fetch": "^2.7.0",
@@ -3181,7 +3202,7 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@natlibfi/marc-record-validate": "^8.0.10"
+				"@natlibfi/marc-record-validate": "^8.0.12"
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
@@ -3238,17 +3259,17 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.3.2.tgz",
-			"integrity": "sha512-sMK+aPg58RNKJkGrqIAJftDiGj+KJ/Oo3d5R5ufMoFXITxxP+YIzIESAKcITRAFwqsxFsHgIEqTJ7Kor3IuKzw==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.3.3.tgz",
+			"integrity": "sha512-umr0QzH7P1A2e/UC9ZVYigVsLfsbVmKKduC3j6N5v5j+cgMqEu4cGXgTnuIk+7oqjRphPyjrLU/hVrD1fDwf6w==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^9.1.1",
-				"@natlibfi/marc-record-merge": "^7.0.6",
-				"@natlibfi/marc-record-validate": "^8.0.11",
-				"@natlibfi/marc-record-validators-melinda": "^11.4.2",
-				"debug": "^4.3.7",
-				"isbn3": "^1.2.3"
+				"@natlibfi/marc-record-merge": "^7.0.7",
+				"@natlibfi/marc-record-validate": "^8.0.12",
+				"@natlibfi/marc-record-validators-melinda": "^11.4.6",
+				"debug": "^4.4.0",
+				"isbn3": "^1.2.4"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3315,9 +3336,8 @@
 			}
 		},
 		"node_modules/@natlibfi/sfs-4900": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sfs-4900/-/sfs-4900-1.1.0.tgz",
-			"integrity": "sha512-bMhDa8QDDnoxsApmAeqF9ndSVgji3ZMkThie5x5N4QndsBOtq7FHdAcXY5jzeorn9zYGYLOJ9DmN5atQEuWVOA==",
+			"version": "1.1.3",
+			"resolved": "git+ssh://git@github.com/NatLibFi/sfs-4900.git#181620a9c9e79f16ecaa81763294056abdc6eb83",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -3484,13 +3504,13 @@
 			}
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.8.tgz",
-			"integrity": "sha512-+3DOBcUn5/rVjlxGvUPKc416SExarAQ+Qe0bqk30YSUjbepwpS7QN0cyKUSifvLJhdMZ0WPzPP5ymut0oonrpQ==",
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+			"integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3505,16 +3525,16 @@
 			"optional": true
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "3.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.12.tgz",
-			"integrity": "sha512-YAJP9UJFZRZ8N+UruTeq78zkdjUHmzsY62J4qKWZ4SXB4QXJ/+680EfXXgkYA2xj77ooMqtUY9m406zGNqwivQ==",
+			"version": "3.0.13",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
+			"integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/types": "^3.7.1",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"@smithy/util-config-provider": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.10",
+				"@smithy/util-middleware": "^3.0.11",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3529,18 +3549,18 @@
 			"optional": true
 		},
 		"node_modules/@smithy/core": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.4.tgz",
-			"integrity": "sha512-iFh2Ymn2sCziBRLPuOOxRPkuCx/2gBdXtBGuCUFLUe6bWYjKnhHyIPqGeNkLZ5Aco/5GjebRTBFiWID3sDbrKw==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.5.tgz",
+			"integrity": "sha512-G8G/sDDhXA7o0bOvkc7bgai6POuSld/+XhNnWAbpQTpLv2OZPvyqQ58tLPPlz0bSNsXktldDDREIv1LczFeNEw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/middleware-serde": "^3.0.10",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/types": "^3.7.1",
+				"@smithy/middleware-serde": "^3.0.11",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/types": "^3.7.2",
 				"@smithy/util-body-length-browser": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.10",
-				"@smithy/util-stream": "^3.3.1",
+				"@smithy/util-middleware": "^3.0.11",
+				"@smithy/util-stream": "^3.3.2",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -3556,16 +3576,16 @@
 			"optional": true
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.7.tgz",
-			"integrity": "sha512-cEfbau+rrWF8ylkmmVAObOmjbTIzKyUC5TkBL58SbLywD0RCBC4JAUKbmtSm2w5KUJNRPGgpGFMvE2FKnuNlWQ==",
+			"version": "3.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
+			"integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/property-provider": "^3.1.10",
-				"@smithy/types": "^3.7.1",
-				"@smithy/url-parser": "^3.0.10",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/types": "^3.7.2",
+				"@smithy/url-parser": "^3.0.11",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3580,15 +3600,15 @@
 			"optional": true
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
-			"integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.2.tgz",
+			"integrity": "sha512-R7rU7Ae3ItU4rC0c5mB2sP5mJNbCfoDc8I5XlYjIZnquyUwec7fEo78F6DA3SmgJgkU1qTMcZJuGblxZsl10ZA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/querystring-builder": "^3.0.10",
-				"@smithy/types": "^3.7.1",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/querystring-builder": "^3.0.11",
+				"@smithy/types": "^3.7.2",
 				"@smithy/util-base64": "^3.0.0",
 				"tslib": "^2.6.2"
 			}
@@ -3601,13 +3621,13 @@
 			"optional": true
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.10.tgz",
-			"integrity": "sha512-3zWGWCHI+FlJ5WJwx73Mw2llYR8aflVyZN5JhoqLxbdPZi6UyKSdCeXAWJw9ja22m6S6Tzz1KZ+kAaSwvydi0g==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
+			"integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"@smithy/util-buffer-from": "^3.0.0",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
@@ -3624,13 +3644,13 @@
 			"optional": true
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.10.tgz",
-			"integrity": "sha512-Lp2L65vFi+cj0vFMu2obpPW69DU+6O5g3086lmI4XcnRCG8PxvpWC7XyaVwJCxsZFzueHjXnrOH/E0pl0zikfA==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
+			"integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			}
 		},
@@ -3662,14 +3682,14 @@
 			"optional": true
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "3.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.12.tgz",
-			"integrity": "sha512-1mDEXqzM20yywaMDuf5o9ue8OkJ373lSPbaSjyEvkWdqELhFMyNNgKGWL/rCSf4KME8B+HlHKuR8u9kRj8HzEQ==",
+			"version": "3.0.13",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
+			"integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/types": "^3.7.1",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3684,19 +3704,19 @@
 			"optional": true
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.4.tgz",
-			"integrity": "sha512-TybiW2LA3kYVd3e+lWhINVu1o26KJbBwOpADnf0L4x/35vLVica77XVR5hvV9+kWeTGeSJ3IHTcYxbRxlbwhsg==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.5.tgz",
+			"integrity": "sha512-VhJNs/s/lyx4weiZdXSloBgoLoS8osV0dKIain8nGmx7of3QFKu5BSdEuk1z/U8x9iwes1i+XCiNusEvuK1ijg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/core": "^2.5.4",
-				"@smithy/middleware-serde": "^3.0.10",
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/shared-ini-file-loader": "^3.1.11",
-				"@smithy/types": "^3.7.1",
-				"@smithy/url-parser": "^3.0.10",
-				"@smithy/util-middleware": "^3.0.10",
+				"@smithy/core": "^2.5.5",
+				"@smithy/middleware-serde": "^3.0.11",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/shared-ini-file-loader": "^3.1.12",
+				"@smithy/types": "^3.7.2",
+				"@smithy/url-parser": "^3.0.11",
+				"@smithy/util-middleware": "^3.0.11",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3711,19 +3731,19 @@
 			"optional": true
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "3.0.28",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.28.tgz",
-			"integrity": "sha512-vK2eDfvIXG1U64FEUhYxoZ1JSj4XFbYWkK36iz02i3pFwWiDz1Q7jKhGTBCwx/7KqJNk4VS7d7cDLXFOvP7M+g==",
+			"version": "3.0.30",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.30.tgz",
+			"integrity": "sha512-6323RL2BvAR3VQpTjHpa52kH/iSHyxd/G9ohb2MkBk2Ucu+oMtRXT8yi7KTSIS9nb58aupG6nO0OlXnQOAcvmQ==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/service-error-classification": "^3.0.10",
-				"@smithy/smithy-client": "^3.4.5",
-				"@smithy/types": "^3.7.1",
-				"@smithy/util-middleware": "^3.0.10",
-				"@smithy/util-retry": "^3.0.10",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/service-error-classification": "^3.0.11",
+				"@smithy/smithy-client": "^3.5.0",
+				"@smithy/types": "^3.7.2",
+				"@smithy/util-middleware": "^3.0.11",
+				"@smithy/util-retry": "^3.0.11",
 				"tslib": "^2.6.2",
 				"uuid": "^9.0.1"
 			},
@@ -3753,13 +3773,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.10.tgz",
-			"integrity": "sha512-MnAuhh+dD14F428ubSJuRnmRsfOpxSzvRhaGVTvd/lrUDE3kxzCCmH8lnVTvoNQnV2BbJ4c15QwZ3UdQBtFNZA==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+			"integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3774,13 +3794,13 @@
 			"optional": true
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.10.tgz",
-			"integrity": "sha512-grCHyoiARDBBGPyw2BeicpjgpsDFWZZxptbVKb3CRd/ZA15F/T6rZjCCuBUjJwdck1nwUuIxYtsS4H9DDpbP5w==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+			"integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3795,15 +3815,15 @@
 			"optional": true
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.11.tgz",
-			"integrity": "sha512-URq3gT3RpDikh/8MBJUB+QGZzfS7Bm6TQTqoh4CqE8NBuyPkWa5eUXj0XFcFfeZVgg3WMh1u19iaXn8FvvXxZw==",
+			"version": "3.1.12",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+			"integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/property-provider": "^3.1.10",
-				"@smithy/shared-ini-file-loader": "^3.1.11",
-				"@smithy/types": "^3.7.1",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/shared-ini-file-loader": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3818,16 +3838,16 @@
 			"optional": true
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.1.tgz",
-			"integrity": "sha512-fr+UAOMGWh6bn4YSEezBCpJn9Ukp9oR4D32sCjCo7U81evE11YePOQ58ogzyfgmjIO79YeOdfXXqr0jyhPQeMg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.2.tgz",
+			"integrity": "sha512-t4ng1DAd527vlxvOfKFYEe6/QFBcsj7WpNlWTyjorwXXcKw3XlltBGbyHfSJ24QT84nF+agDha9tNYpzmSRZPA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/abort-controller": "^3.1.8",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/querystring-builder": "^3.0.10",
-				"@smithy/types": "^3.7.1",
+				"@smithy/abort-controller": "^3.1.9",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/querystring-builder": "^3.0.11",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3842,13 +3862,13 @@
 			"optional": true
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.10.tgz",
-			"integrity": "sha512-n1MJZGTorTH2DvyTVj+3wXnd4CzjJxyXeOgnTlgNVFxaaMeT4OteEp4QrzF8p9ee2yg42nvyVK6R/awLCakjeQ==",
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+			"integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3863,13 +3883,13 @@
 			"optional": true
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.7.tgz",
-			"integrity": "sha512-FP2LepWD0eJeOTm0SjssPcgqAlDFzOmRXqXmGhfIM52G7Lrox/pcpQf6RP4F21k0+O12zaqQt5fCDOeBtqY6Cg==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+			"integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3884,13 +3904,13 @@
 			"optional": true
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.10.tgz",
-			"integrity": "sha512-nT9CQF3EIJtIUepXQuBFb8dxJi3WVZS3XfuDksxSCSn+/CzZowRLdhDn+2acbBv8R6eaJqPupoI/aRFIImNVPQ==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+			"integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"@smithy/util-uri-escape": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -3906,13 +3926,13 @@
 			"optional": true
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.10.tgz",
-			"integrity": "sha512-Oa0XDcpo9SmjhiDD9ua2UyM3uU01ZTuIrNdZvzwUTykW1PM8o2yJvMh1Do1rY5sUQg4NDV70dMi0JhDx4GyxuQ==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+			"integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3927,26 +3947,26 @@
 			"optional": true
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.10.tgz",
-			"integrity": "sha512-zHe642KCqDxXLuhs6xmHVgRwy078RfqxP2wRDpIyiF8EmsWXptMwnMwbVa50lw+WOGNrYm9zbaEg0oDe3PTtvQ==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+			"integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1"
+				"@smithy/types": "^3.7.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.11.tgz",
-			"integrity": "sha512-AUdrIZHFtUgmfSN4Gq9nHu3IkHMa1YDcN+s061Nfm+6pQ0mJy85YQDB0tZBCmls0Vuj22pLwDPmL92+Hvfwwlg==",
+			"version": "3.1.12",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+			"integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3961,17 +3981,17 @@
 			"optional": true
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.3.tgz",
-			"integrity": "sha512-pPSQQ2v2vu9vc8iew7sszLd0O09I5TRc5zhY71KA+Ao0xYazIG+uLeHbTJfIWGO3BGVLiXjUr3EEeCcEQLjpWQ==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.4.tgz",
+			"integrity": "sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
 				"@smithy/is-array-buffer": "^3.0.0",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/types": "^3.7.1",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/types": "^3.7.2",
 				"@smithy/util-hex-encoding": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.10",
+				"@smithy/util-middleware": "^3.0.11",
 				"@smithy/util-uri-escape": "^3.0.0",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
@@ -3988,18 +4008,18 @@
 			"optional": true
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.5.tgz",
-			"integrity": "sha512-k0sybYT9zlP79sIKd1XGm4TmK0AS1nA2bzDHXx7m0nGi3RQ8dxxQUs4CPkSmQTKAo+KF9aINU3KzpGIpV7UoMw==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.5.0.tgz",
+			"integrity": "sha512-Y8FeOa7gbDfCWf7njrkoRATPa5eNLUEjlJS5z5rXatYuGkCb80LbHcu8AQR8qgAZZaNHCLyo2N+pxPsV7l+ivg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/core": "^2.5.4",
-				"@smithy/middleware-endpoint": "^3.2.4",
-				"@smithy/middleware-stack": "^3.0.10",
-				"@smithy/protocol-http": "^4.1.7",
-				"@smithy/types": "^3.7.1",
-				"@smithy/util-stream": "^3.3.1",
+				"@smithy/core": "^2.5.5",
+				"@smithy/middleware-endpoint": "^3.2.5",
+				"@smithy/middleware-stack": "^3.0.11",
+				"@smithy/protocol-http": "^4.1.8",
+				"@smithy/types": "^3.7.2",
+				"@smithy/util-stream": "^3.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4014,9 +4034,9 @@
 			"optional": true
 		},
 		"node_modules/@smithy/types": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.1.tgz",
-			"integrity": "sha512-XKLcLXZY7sUQgvvWyeaL/qwNPp6V3dWcUjqrQKjSb+tzYiCy340R/c64LV5j+Tnb2GhmunEX0eou+L+m2hJNYA==",
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+			"integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
@@ -4034,14 +4054,14 @@
 			"optional": true
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.10.tgz",
-			"integrity": "sha512-j90NUalTSBR2NaZTuruEgavSdh8MLirf58LoGSk4AtQfyIymogIhgnGUU2Mga2bkMkpSoC9gxb74xBXL5afKAQ==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+			"integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/querystring-parser": "^3.0.10",
-				"@smithy/types": "^3.7.1",
+				"@smithy/querystring-parser": "^3.0.11",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			}
 		},
@@ -4153,15 +4173,15 @@
 			"optional": true
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "3.0.28",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.28.tgz",
-			"integrity": "sha512-6bzwAbZpHRFVJsOztmov5PGDmJYsbNSoIEfHSJJyFLzfBGCCChiO3od9k7E/TLgrCsIifdAbB9nqbVbyE7wRUw==",
+			"version": "3.0.30",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.30.tgz",
+			"integrity": "sha512-nLuGmgfcr0gzm64pqF2UT4SGWVG8UGviAdayDlVzJPNa6Z4lqvpDzdRXmLxtOdEjVlTOEdpZ9dd3ZMMu488mzg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/property-provider": "^3.1.10",
-				"@smithy/smithy-client": "^3.4.5",
-				"@smithy/types": "^3.7.1",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/smithy-client": "^3.5.0",
+				"@smithy/types": "^3.7.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -4177,18 +4197,18 @@
 			"optional": true
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "3.0.28",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.28.tgz",
-			"integrity": "sha512-78ENJDorV1CjOQselGmm3+z7Yqjj5HWCbjzh0Ixuq736dh1oEnD9sAttSBNSLlpZsX8VQnmERqA2fEFlmqWn8w==",
+			"version": "3.0.30",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.30.tgz",
+			"integrity": "sha512-OD63eWoH68vp75mYcfYyuVH+p7Li/mY4sYOROnauDrtObo1cS4uWfsy/zhOTW8F8ZPxQC1ZXZKVxoxvMGUv2Ow==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/config-resolver": "^3.0.12",
-				"@smithy/credential-provider-imds": "^3.2.7",
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/property-provider": "^3.1.10",
-				"@smithy/smithy-client": "^3.4.5",
-				"@smithy/types": "^3.7.1",
+				"@smithy/config-resolver": "^3.0.13",
+				"@smithy/credential-provider-imds": "^3.2.8",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/property-provider": "^3.1.11",
+				"@smithy/smithy-client": "^3.5.0",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4203,14 +4223,14 @@
 			"optional": true
 		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.6.tgz",
-			"integrity": "sha512-mFV1t3ndBh0yZOJgWxO9J/4cHZVn5UG1D8DeCc6/echfNkeEJWu9LD7mgGH5fHrEdR7LDoWw7PQO6QiGpHXhgA==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
+			"integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.11",
-				"@smithy/types": "^3.7.1",
+				"@smithy/node-config-provider": "^3.1.12",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4245,13 +4265,13 @@
 			"optional": true
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.10.tgz",
-			"integrity": "sha512-eJO+/+RsrG2RpmY68jZdwQtnfsxjmPxzMlQpnHKjFPwrYqvlcT+fHdT+ZVwcjlWSrByOhGr9Ff2GG17efc192A==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+			"integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.1",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4266,14 +4286,14 @@
 			"optional": true
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.10.tgz",
-			"integrity": "sha512-1l4qatFp4PiU6j7UsbasUHL2VU023NRB/gfaa1M0rDqVrRN4g3mCArLRyH3OuktApA4ye+yjWQHjdziunw2eWA==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+			"integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/service-error-classification": "^3.0.10",
-				"@smithy/types": "^3.7.1",
+				"@smithy/service-error-classification": "^3.0.11",
+				"@smithy/types": "^3.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4288,15 +4308,15 @@
 			"optional": true
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.1.tgz",
-			"integrity": "sha512-Ff68R5lJh2zj+AUTvbAU/4yx+6QPRzg7+pI7M1FbtQHcRIp7xvguxVsQBKyB3fwiOwhAKu0lnNyYBaQfSW6TNw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.2.tgz",
+			"integrity": "sha512-sInAqdiVeisUGYAv/FrXpmJ0b4WTFmciTRqzhb7wVuem9BHvhIG7tpiYHLDWrl2stOokNZpTTGqz3mzB2qFwXg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^4.1.1",
-				"@smithy/node-http-handler": "^3.3.1",
-				"@smithy/types": "^3.7.1",
+				"@smithy/fetch-http-handler": "^4.1.2",
+				"@smithy/node-http-handler": "^3.3.2",
+				"@smithy/types": "^3.7.2",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-buffer-from": "^3.0.0",
 				"@smithy/util-hex-encoding": "^3.0.0",
@@ -4363,9 +4383,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.10.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-			"integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+			"version": "22.10.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+			"integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.20.0"
@@ -4573,9 +4593,9 @@
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
+			"integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5041,6 +5061,7 @@
 			"version": "4.24.2",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
 			"integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5109,6 +5130,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/buffer-more-ints": {
@@ -5150,16 +5172,44 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
 			"license": "MIT",
 			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.0",
 				"es-define-property": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
 				"get-intrinsic": "^1.2.4",
-				"set-function-length": "^1.2.1"
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+			"integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.2.tgz",
+			"integrity": "sha512-0lk0PHFe/uz0vl527fG9CgdE9WdafjDbCXvBbs+LUv000TVt2Jjhqbs4Jwm8gz070w8xXyEAxrPOMullsxXeGg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"get-intrinsic": "^1.2.5"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -5189,9 +5239,10 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001686",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001686.tgz",
-			"integrity": "sha512-Y7deg0Aergpa24M3qLC5xjNklnKnhsmSyR/V89dLZ1n0ucJIFNs7PgR2Yfa/Zf6W79SbBicgtGxZr2juHkEUIA==",
+			"version": "1.0.30001688",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001688.tgz",
+			"integrity": "sha512-Nmqpru91cuABu/DTCXbM2NSRHzM2uVHfPnhJ/1zEAJx/ILBRVmz3pzH4N7DZqbdG0gWClsCC05Oj0mJ/1AWMbA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5330,6 +5381,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
 			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-plain-object": "^2.0.4",
@@ -5426,6 +5478,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/concat-map": {
@@ -5439,6 +5492,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/core-js": {
@@ -5576,9 +5630,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -5800,6 +5854,20 @@
 				"url": "https://dotenvx.com"
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
+			"integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -5808,9 +5876,10 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.71",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.71.tgz",
-			"integrity": "sha512-dB68l59BI75W1BUGVTAEJy45CEVuEGy9qPVVQ8pnHyHMn36PLPPoE1mjLH+lo9rKulO3HC2OhbACI/8tCqJBcA==",
+			"version": "1.5.73",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.73.tgz",
+			"integrity": "sha512-8wGNxG9tAG5KhGd3eeA0o6ixhiNdgr0DcHWm85XPCphwZgD1lIEoi6t3VERayWao7SF7AAZTw6oARGJeVjH8Kg==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
@@ -5920,13 +5989,10 @@
 			"license": "MIT"
 		},
 		"node_modules/es-define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"license": "MIT",
-			"dependencies": {
-				"get-intrinsic": "^1.2.4"
-			},
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5944,7 +6010,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
 			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -6790,6 +6855,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
 			"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"commondir": "^1.0.1",
@@ -7013,6 +7079,7 @@
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -7038,16 +7105,21 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+			"integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
 			"license": "MIT",
 			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"dunder-proto": "^1.0.0",
+				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
 				"function-bind": "^1.1.2",
-				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3",
-				"hasown": "^2.0.0"
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7160,6 +7232,7 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -7271,12 +7344,13 @@
 			}
 		},
 		"node_modules/has-proto": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.1.0.tgz",
-			"integrity": "sha512-QLdzI9IIO1Jg7f9GT1gXpPpXArAn6cS31R1eEZqz08Gc+uQ8/XiqHWt17Fiw+2p6oTTIq5GXEpQkAlA88YRl/Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+			"integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7"
+				"dunder-proto": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7731,12 +7805,14 @@
 			}
 		},
 		"node_modules/is-data-view": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-			"integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+			"integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"call-bound": "^1.0.2",
+				"get-intrinsic": "^1.2.6",
 				"is-typed-array": "^1.1.13"
 			},
 			"engines": {
@@ -8076,6 +8152,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"isobject": "^3.0.1"
@@ -8085,14 +8162,14 @@
 			}
 		},
 		"node_modules/is-regex": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.0.tgz",
-			"integrity": "sha512-B6ohK4ZmoftlUe+uvenXSbPJFo6U37BH7oO1B3nQH8f/7h27N56s85MhUtbFJAziz5dcmuR3i8ovUl35zp8pFA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
-				"gopd": "^1.1.0",
+				"call-bound": "^1.0.2",
+				"gopd": "^1.2.0",
 				"has-tostringtag": "^1.0.2",
 				"hasown": "^2.0.2"
 			},
@@ -8306,6 +8383,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -8485,6 +8563,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -8508,9 +8587,10 @@
 			"license": "MIT"
 		},
 		"node_modules/jsesc": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-			"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
@@ -8550,6 +8630,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"json5": "lib/cli.js"
@@ -8590,6 +8671,7 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -8718,6 +8800,7 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
@@ -8727,6 +8810,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
 			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pify": "^4.0.1",
@@ -8740,9 +8824,19 @@
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
 			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
+			"integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/memjs": {
@@ -9105,9 +9199,9 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "8.8.3",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.8.3.tgz",
-			"integrity": "sha512-/I4n/DcXqXyIiLRfAmUIiTjj3vXfeISke8dt4U4Y8Wfm074Wa6sXnQrXN49NFOFf2mM1kUdOXryoBvkuCnr+Qw==",
+			"version": "8.8.4",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.8.4.tgz",
+			"integrity": "sha512-yJbn695qCsqDO+xyPII29x2R7flzXhxCDv09mMZPSGllf0sm4jKw3E9s9uvQ9hjO6bL2xjU8KKowYqcY9eSTMQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bson": "^6.7.0",
@@ -9395,9 +9489,10 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/nodemailer": {
@@ -9808,6 +9903,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-try": "^2.0.0"
@@ -9849,6 +9945,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -10096,6 +10193,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -10115,6 +10213,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -10124,6 +10223,7 @@
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
 			"integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -10133,6 +10233,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
 			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"find-up": "^3.0.0"
@@ -10145,6 +10246,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^3.0.0"
@@ -10157,6 +10259,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^3.0.0",
@@ -10170,6 +10273,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^2.0.0"
@@ -10182,6 +10286,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
 			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -10410,19 +10515,20 @@
 			}
 		},
 		"node_modules/reflect.getprototypeof": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.7.tgz",
-			"integrity": "sha512-bMvFGIUKlc/eSfXNX+aZ+EL95/EgZzuwA0OBPTbZZDEJw/0AkentjMuM1oiRfwHrshqk4RzdgiTg5CcDalXN5g==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.8.tgz",
+			"integrity": "sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bind": "^1.0.8",
 				"define-properties": "^1.2.1",
+				"dunder-proto": "^1.0.0",
 				"es-abstract": "^1.23.5",
 				"es-errors": "^1.3.0",
 				"get-intrinsic": "^1.2.4",
-				"gopd": "^1.0.1",
-				"which-builtin-type": "^1.1.4"
+				"gopd": "^1.2.0",
+				"which-builtin-type": "^1.2.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -10522,6 +10628,19 @@
 			},
 			"bin": {
 				"regjsparser": "bin/parser"
+			}
+		},
+		"node_modules/regjsparser/node_modules/jsesc": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+			"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/release-zalgo": {
@@ -10646,15 +10765,16 @@
 			}
 		},
 		"node_modules/safe-array-concat": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-			"integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+			"integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
-				"get-intrinsic": "^1.2.4",
-				"has-symbols": "^1.0.3",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
+				"get-intrinsic": "^1.2.6",
+				"has-symbols": "^1.1.0",
 				"isarray": "^2.0.5"
 			},
 			"engines": {
@@ -10731,6 +10851,7 @@
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -10790,6 +10911,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
 			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"kind-of": "^6.0.2"
@@ -10822,15 +10944,69 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
 				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.4",
-				"object-inspect": "^1.13.1"
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -10925,6 +11101,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -10934,6 +11111,7 @@
 			"version": "0.5.21",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
@@ -11106,16 +11284,19 @@
 			}
 		},
 		"node_modules/string.prototype.trim": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-			"integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+			"integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
+				"define-data-property": "^1.1.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.0",
-				"es-object-atoms": "^1.0.0"
+				"es-abstract": "^1.23.5",
+				"es-object-atoms": "^1.0.0",
+				"has-property-descriptors": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -11125,15 +11306,19 @@
 			}
 		},
 		"node_modules/string.prototype.trimend": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-			"integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+			"integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
 				"define-properties": "^1.2.1",
 				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -11630,6 +11815,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
 			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -12035,6 +12221,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "3.7.3",
+	"version": "3.7.4-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -36,22 +36,22 @@
 	"dependencies": {
 		"@babel/runtime": "^7.26.0",
 		"@natlibfi/marc-record": "^9.1.1",
-		"@natlibfi/marc-record-merge": "^7.0.6",
+		"@natlibfi/marc-record-merge": "^7.0.7",
 		"@natlibfi/marc-record-serializers": "^10.1.4",
-		"@natlibfi/melinda-backend-commons": "^2.3.5",
+		"@natlibfi/melinda-backend-commons": "^2.3.6",
 		"@natlibfi/melinda-commons": "^13.0.18",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.2",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.3",
 		"@natlibfi/melinda-record-match-validator": "^2.2.4",
 		"@natlibfi/melinda-record-matching": "^4.3.4",
 		"@natlibfi/melinda-rest-api-commons": "^4.2.2",
 		"@natlibfi/sru-client": "^6.0.16",
-		"debug": "^4.3.7",
+		"debug": "^4.4.0",
 		"deep-eql": "^4.1.4",
 		"deep-object-diff": "^1.1.9",
 		"http-status": "^1.8.1"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.25.9",
+		"@babel/cli": "^7.26.4",
 		"@babel/core": "^7.26.0",
 		"@babel/node": "^7.26.0",
 		"@babel/plugin-transform-runtime": "^7.25.9",


### PR DESCRIPTION
* Update handling 594 fields for pre-publication records [MELKEHITYS-3107] by updating `@natlibfi/melinda-marc-record-merge-reducers` from 2.3.2 to 2.3.3

* Bump the production-dependencies group across 1 directory with 2 updates (#495)

Bumps the production-dependencies group with 1 update in the / directory: [@natlibfi/melinda-marc-record-merge-reducers](https://github.com/natlibfi/melinda-marc-record-merge-reducers-js).

Updates `@natlibfi/melinda-marc-record-merge-reducers` from 2.3.2 to 2.3.3
- [Release notes](https://github.com/natlibfi/melinda-marc-record-merge-reducers-js/releases)
- [Commits](https://github.com/natlibfi/melinda-marc-record-merge-reducers-js/compare/v2.3.2...v2.3.3)

Updates `debug` from 4.3.7 to 4.4.0
- [Release notes](https://github.com/debug-js/debug/releases)
- [Commits](https://github.com/debug-js/debug/compare/4.3.7...4.4.0)

* Update deps

* 3.7.4-alpha.1