### PR TITLE
Handle non-all-capital prepublication fields ; Dependency & Maintenance Update (#501)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 23.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.7.5-alpha.1",
+	"version": "3.7.5-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.7.5-alpha.1",
+			"version": "3.7.5-alpha.2",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@natlibfi/marc-record-merge": "^7.0.8",
 				"@natlibfi/marc-record-serializers": "^10.1.5",
 				"@natlibfi/melinda-backend-commons": "^2.3.6",
-				"@natlibfi/melinda-commons": "^13.0.19-alpha.3",
+				"@natlibfi/melinda-commons": "^13.0.19",
 				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.3",
 				"@natlibfi/melinda-record-match-validator": "^2.2.5",
 				"@natlibfi/melinda-record-matching": "^4.3.4",
@@ -40,7 +40,7 @@
 				"chai": "^4.5.0",
 				"cross-env": "^7.0.3",
 				"eslint": "^8.57.1",
-				"mocha": "^11.0.1",
+				"mocha": "^11.1.0",
 				"nodemon": "^3.1.9",
 				"nyc": "^17.1.0"
 			},
@@ -3198,43 +3198,6 @@
 				"@natlibfi/marc-record-validate": "^8.0.12"
 			}
 		},
-		"node_modules/@natlibfi/marc-record-validators-melinda/node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.18",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.18.tgz",
-			"integrity": "sha512-Eoj23IBDkomg+7pvKm9+T4ON24aFeunbD8zZ6GdxFOXft8euu754MkYROP26FssmLZlIPeYKWy+9GZT9RoS1HQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@natlibfi/marc-record": "^9.0.2",
-				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.15",
-				"debug": "^4.3.7",
-				"deep-eql": "^5.0.2",
-				"http-status": "^1.7.4",
-				"moment": "^2.30.1",
-				"nock": "^13.5.5"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@natlibfi/marc-record-validators-melinda/node_modules/deep-eql": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@natlibfi/marc-record-validators-melinda/node_modules/http-status": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.8.1.tgz",
-			"integrity": "sha512-YQF7j8Qf/Rlby0IbRPiWfNZt6aeUv3K0Pi0x3crbMZN+7F8dPn5k4b3n897vpM1Vk8Mg2fhOYc9fktKEQWMy/Q==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.3.6.tgz",
@@ -3261,9 +3224,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.19-alpha.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.19-alpha.3.tgz",
-			"integrity": "sha512-jGvX6Si566NsjAeafjMzwck6UBq/LFLA3KawH/OgyJIDuRz/sbXGkGHluENvKRN6e5e/PffeoK+11HvmzBg7bg==",
+			"version": "13.0.19",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.19.tgz",
+			"integrity": "sha512-v4EM2ZQbjtY9ZYF0GBoEA7pXOamTuNSWPXXCSM1Yjzz0Jv8pskrrH4Zdwt/ZfQzHGrEmbOBHJ8F7HYLlvq4mfQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^9.1.2",
@@ -3308,43 +3271,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@natlibfi/melinda-record-match-validator/node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.18",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.18.tgz",
-			"integrity": "sha512-Eoj23IBDkomg+7pvKm9+T4ON24aFeunbD8zZ6GdxFOXft8euu754MkYROP26FssmLZlIPeYKWy+9GZT9RoS1HQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@natlibfi/marc-record": "^9.0.2",
-				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.15",
-				"debug": "^4.3.7",
-				"deep-eql": "^5.0.2",
-				"http-status": "^1.7.4",
-				"moment": "^2.30.1",
-				"nock": "^13.5.5"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@natlibfi/melinda-record-match-validator/node_modules/deep-eql": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@natlibfi/melinda-record-match-validator/node_modules/http-status": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.8.1.tgz",
-			"integrity": "sha512-YQF7j8Qf/Rlby0IbRPiWfNZt6aeUv3K0Pi0x3crbMZN+7F8dPn5k4b3n897vpM1Vk8Mg2fhOYc9fktKEQWMy/Q==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/@natlibfi/melinda-record-matching": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-4.3.4.tgz",
@@ -3364,43 +3290,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@natlibfi/melinda-record-matching/node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.18",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.18.tgz",
-			"integrity": "sha512-Eoj23IBDkomg+7pvKm9+T4ON24aFeunbD8zZ6GdxFOXft8euu754MkYROP26FssmLZlIPeYKWy+9GZT9RoS1HQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@natlibfi/marc-record": "^9.0.2",
-				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.15",
-				"debug": "^4.3.7",
-				"deep-eql": "^5.0.2",
-				"http-status": "^1.7.4",
-				"moment": "^2.30.1",
-				"nock": "^13.5.5"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@natlibfi/melinda-record-matching/node_modules/deep-eql": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@natlibfi/melinda-record-matching/node_modules/http-status": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.8.1.tgz",
-			"integrity": "sha512-YQF7j8Qf/Rlby0IbRPiWfNZt6aeUv3K0Pi0x3crbMZN+7F8dPn5k4b3n897vpM1Vk8Mg2fhOYc9fktKEQWMy/Q==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">= 0.4.0"
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
@@ -3424,43 +3313,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@natlibfi/melinda-rest-api-commons/node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.18",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.18.tgz",
-			"integrity": "sha512-Eoj23IBDkomg+7pvKm9+T4ON24aFeunbD8zZ6GdxFOXft8euu754MkYROP26FssmLZlIPeYKWy+9GZT9RoS1HQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@natlibfi/marc-record": "^9.0.2",
-				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.15",
-				"debug": "^4.3.7",
-				"deep-eql": "^5.0.2",
-				"http-status": "^1.7.4",
-				"moment": "^2.30.1",
-				"nock": "^13.5.5"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@natlibfi/melinda-rest-api-commons/node_modules/@natlibfi/melinda-commons/node_modules/http-status": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.8.1.tgz",
-			"integrity": "sha512-YQF7j8Qf/Rlby0IbRPiWfNZt6aeUv3K0Pi0x3crbMZN+7F8dPn5k4b3n897vpM1Vk8Mg2fhOYc9fktKEQWMy/Q==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/@natlibfi/melinda-rest-api-commons/node_modules/deep-eql": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/@natlibfi/sfs-4900": {
@@ -8793,12 +8645,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"license": "ISC"
-		},
 		"node_modules/json5": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9111,9 +8957,9 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.0.1.tgz",
-			"integrity": "sha512-+3GkODfsDG71KSCQhc4IekSW+ItCK/kiez1Z28ksWvYhKXV/syxMlerR/sC7whDp7IyreZ4YxceMLdTs5hQE8A==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
+			"integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9134,8 +8980,8 @@
 				"strip-json-comments": "^3.1.1",
 				"supports-color": "^8.1.1",
 				"workerpool": "^6.5.1",
-				"yargs": "^16.2.0",
-				"yargs-parser": "^20.2.9",
+				"yargs": "^17.7.2",
+				"yargs-parser": "^21.1.1",
 				"yargs-unparser": "^2.0.0"
 			},
 			"bin": {
@@ -9152,18 +8998,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"license": "Python-2.0"
-		},
-		"node_modules/mocha/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
 		},
 		"node_modules/mocha/node_modules/find-up": {
 			"version": "5.0.0",
@@ -9307,25 +9141,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/mocha/node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/moment": {
@@ -9510,20 +9325,6 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/nock": {
-			"version": "13.5.6",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-			"integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"propagate": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 10.13"
 			}
 		},
 		"node_modules/node-environment-flags": {
@@ -10525,15 +10326,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/propagate": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-			"integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/pstree.remy": {
@@ -12418,13 +12210,12 @@
 			}
 		},
 		"node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"license": "ISC",
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/yargs-unparser": {
@@ -12467,15 +12258,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/yargs/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,29 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.7.4",
+	"version": "3.7.5-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.7.4",
+			"version": "3.7.5-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.26.0",
-				"@natlibfi/marc-record": "^9.1.1",
-				"@natlibfi/marc-record-merge": "^7.0.7",
-				"@natlibfi/marc-record-serializers": "^10.1.4",
+				"@natlibfi/marc-record": "^9.1.2",
+				"@natlibfi/marc-record-merge": "^7.0.8",
+				"@natlibfi/marc-record-serializers": "^10.1.5",
 				"@natlibfi/melinda-backend-commons": "^2.3.6",
-				"@natlibfi/melinda-commons": "^13.0.18",
+				"@natlibfi/melinda-commons": "^13.0.19-alpha.3",
 				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.3",
-				"@natlibfi/melinda-record-match-validator": "^2.2.4",
+				"@natlibfi/melinda-record-match-validator": "^2.2.5",
 				"@natlibfi/melinda-record-matching": "^4.3.4",
-				"@natlibfi/melinda-rest-api-commons": "^4.2.2",
-				"@natlibfi/sru-client": "^6.0.16",
+				"@natlibfi/melinda-rest-api-commons": "^4.2.4-alpha.5",
+				"@natlibfi/sru-client": "^6.0.17",
 				"debug": "^4.4.0",
 				"deep-eql": "^4.1.4",
 				"deep-object-diff": "^1.1.9",
-				"http-status": "^1.8.1"
+				"http-status": "^2.1.0"
 			},
 			"devDependencies": {
 				"@babel/cli": "^7.26.4",
@@ -41,7 +41,7 @@
 				"cross-env": "^7.0.3",
 				"eslint": "^8.57.1",
 				"mocha": "^11.0.1",
-				"nodemon": "^3.1.7",
+				"nodemon": "^3.1.9",
 				"nyc": "^17.1.0"
 			},
 			"engines": {
@@ -82,6 +82,7 @@
 			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-js": "^5.2.0",
 				"@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -98,6 +99,7 @@
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -111,6 +113,7 @@
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@smithy/is-array-buffer": "^2.2.0",
 				"tslib": "^2.6.2"
@@ -125,6 +128,7 @@
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@smithy/util-buffer-from": "^2.2.0",
 				"tslib": "^2.6.2"
@@ -138,7 +142,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-crypto/sha256-js": {
 			"version": "5.2.0",
@@ -146,6 +151,7 @@
 			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -160,7 +166,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-crypto/supports-web-crypto": {
 			"version": "5.2.0",
@@ -168,6 +175,7 @@
 			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			}
@@ -177,7 +185,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-crypto/util": {
 			"version": "5.2.0",
@@ -185,6 +194,7 @@
 			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "^3.222.0",
 				"@smithy/util-utf8": "^2.0.0",
@@ -197,6 +207,7 @@
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -210,6 +221,7 @@
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@smithy/is-array-buffer": "^2.2.0",
 				"tslib": "^2.6.2"
@@ -224,6 +236,7 @@
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@smithy/util-buffer-from": "^2.2.0",
 				"tslib": "^2.6.2"
@@ -237,59 +250,59 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.709.0.tgz",
-			"integrity": "sha512-I5a8ilF+jKAz6fmOOuHy2UEcod9ikRGBjACcC6ayxs4z4VqTnWynD6ALKvtUR3lk1Ur6nzAG1tTm/qAYKKmyBg==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.730.0.tgz",
+			"integrity": "sha512-iJt2pL6RqWg7R3pja1WfcC2+oTjwaKFYndNE9oUQqyc6RN24XWUtGy9JnWqTUOy8jYzaP2eoF00fGeasSBX+Dw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.709.0",
-				"@aws-sdk/client-sts": "3.709.0",
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/credential-provider-node": "3.709.0",
-				"@aws-sdk/middleware-host-header": "3.709.0",
-				"@aws-sdk/middleware-logger": "3.709.0",
-				"@aws-sdk/middleware-recursion-detection": "3.709.0",
-				"@aws-sdk/middleware-user-agent": "3.709.0",
-				"@aws-sdk/region-config-resolver": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@aws-sdk/util-endpoints": "3.709.0",
-				"@aws-sdk/util-user-agent-browser": "3.709.0",
-				"@aws-sdk/util-user-agent-node": "3.709.0",
-				"@smithy/config-resolver": "^3.0.13",
-				"@smithy/core": "^2.5.5",
-				"@smithy/fetch-http-handler": "^4.1.2",
-				"@smithy/hash-node": "^3.0.11",
-				"@smithy/invalid-dependency": "^3.0.11",
-				"@smithy/middleware-content-length": "^3.0.13",
-				"@smithy/middleware-endpoint": "^3.2.5",
-				"@smithy/middleware-retry": "^3.0.30",
-				"@smithy/middleware-serde": "^3.0.11",
-				"@smithy/middleware-stack": "^3.0.11",
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/node-http-handler": "^3.3.2",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/smithy-client": "^3.5.0",
-				"@smithy/types": "^3.7.2",
-				"@smithy/url-parser": "^3.0.11",
-				"@smithy/util-base64": "^3.0.0",
-				"@smithy/util-body-length-browser": "^3.0.0",
-				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.30",
-				"@smithy/util-defaults-mode-node": "^3.0.30",
-				"@smithy/util-endpoints": "^2.1.7",
-				"@smithy/util-middleware": "^3.0.11",
-				"@smithy/util-retry": "^3.0.11",
-				"@smithy/util-utf8": "^3.0.0",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/credential-provider-node": "3.730.0",
+				"@aws-sdk/middleware-host-header": "3.723.0",
+				"@aws-sdk/middleware-logger": "3.723.0",
+				"@aws-sdk/middleware-recursion-detection": "3.723.0",
+				"@aws-sdk/middleware-user-agent": "3.730.0",
+				"@aws-sdk/region-config-resolver": "3.723.0",
+				"@aws-sdk/types": "3.723.0",
+				"@aws-sdk/util-endpoints": "3.730.0",
+				"@aws-sdk/util-user-agent-browser": "3.723.0",
+				"@aws-sdk/util-user-agent-node": "3.730.0",
+				"@smithy/config-resolver": "^4.0.0",
+				"@smithy/core": "^3.0.0",
+				"@smithy/fetch-http-handler": "^5.0.0",
+				"@smithy/hash-node": "^4.0.0",
+				"@smithy/invalid-dependency": "^4.0.0",
+				"@smithy/middleware-content-length": "^4.0.0",
+				"@smithy/middleware-endpoint": "^4.0.0",
+				"@smithy/middleware-retry": "^4.0.0",
+				"@smithy/middleware-serde": "^4.0.0",
+				"@smithy/middleware-stack": "^4.0.0",
+				"@smithy/node-config-provider": "^4.0.0",
+				"@smithy/node-http-handler": "^4.0.0",
+				"@smithy/protocol-http": "^5.0.0",
+				"@smithy/smithy-client": "^4.0.0",
+				"@smithy/types": "^4.0.0",
+				"@smithy/url-parser": "^4.0.0",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-body-length-node": "^4.0.0",
+				"@smithy/util-defaults-mode-browser": "^4.0.0",
+				"@smithy/util-defaults-mode-node": "^4.0.0",
+				"@smithy/util-endpoints": "^3.0.0",
+				"@smithy/util-middleware": "^4.0.0",
+				"@smithy/util-retry": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
@@ -297,206 +310,90 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.709.0.tgz",
-			"integrity": "sha512-Qxeo8cN0jNy6Wnbqq4wucffAGJM6sJjofoTgNtPA6cC7sPYx7aYC6OAAAo6NaMRY+WywOKdS9Wgjx2QYRxKx7w==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.730.0.tgz",
+			"integrity": "sha512-mI8kqkSuVlZklewEmN7jcbBMyVODBld3MsTjCKSl5ztduuPX69JD7nXLnWWPkw1PX4aGTO24AEoRMGNxntoXUg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/middleware-host-header": "3.709.0",
-				"@aws-sdk/middleware-logger": "3.709.0",
-				"@aws-sdk/middleware-recursion-detection": "3.709.0",
-				"@aws-sdk/middleware-user-agent": "3.709.0",
-				"@aws-sdk/region-config-resolver": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@aws-sdk/util-endpoints": "3.709.0",
-				"@aws-sdk/util-user-agent-browser": "3.709.0",
-				"@aws-sdk/util-user-agent-node": "3.709.0",
-				"@smithy/config-resolver": "^3.0.13",
-				"@smithy/core": "^2.5.5",
-				"@smithy/fetch-http-handler": "^4.1.2",
-				"@smithy/hash-node": "^3.0.11",
-				"@smithy/invalid-dependency": "^3.0.11",
-				"@smithy/middleware-content-length": "^3.0.13",
-				"@smithy/middleware-endpoint": "^3.2.5",
-				"@smithy/middleware-retry": "^3.0.30",
-				"@smithy/middleware-serde": "^3.0.11",
-				"@smithy/middleware-stack": "^3.0.11",
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/node-http-handler": "^3.3.2",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/smithy-client": "^3.5.0",
-				"@smithy/types": "^3.7.2",
-				"@smithy/url-parser": "^3.0.11",
-				"@smithy/util-base64": "^3.0.0",
-				"@smithy/util-body-length-browser": "^3.0.0",
-				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.30",
-				"@smithy/util-defaults-mode-node": "^3.0.30",
-				"@smithy/util-endpoints": "^2.1.7",
-				"@smithy/util-middleware": "^3.0.11",
-				"@smithy/util-retry": "^3.0.11",
-				"@smithy/util-utf8": "^3.0.0",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/middleware-host-header": "3.723.0",
+				"@aws-sdk/middleware-logger": "3.723.0",
+				"@aws-sdk/middleware-recursion-detection": "3.723.0",
+				"@aws-sdk/middleware-user-agent": "3.730.0",
+				"@aws-sdk/region-config-resolver": "3.723.0",
+				"@aws-sdk/types": "3.723.0",
+				"@aws-sdk/util-endpoints": "3.730.0",
+				"@aws-sdk/util-user-agent-browser": "3.723.0",
+				"@aws-sdk/util-user-agent-node": "3.730.0",
+				"@smithy/config-resolver": "^4.0.0",
+				"@smithy/core": "^3.0.0",
+				"@smithy/fetch-http-handler": "^5.0.0",
+				"@smithy/hash-node": "^4.0.0",
+				"@smithy/invalid-dependency": "^4.0.0",
+				"@smithy/middleware-content-length": "^4.0.0",
+				"@smithy/middleware-endpoint": "^4.0.0",
+				"@smithy/middleware-retry": "^4.0.0",
+				"@smithy/middleware-serde": "^4.0.0",
+				"@smithy/middleware-stack": "^4.0.0",
+				"@smithy/node-config-provider": "^4.0.0",
+				"@smithy/node-http-handler": "^4.0.0",
+				"@smithy/protocol-http": "^5.0.0",
+				"@smithy/smithy-client": "^4.0.0",
+				"@smithy/types": "^4.0.0",
+				"@smithy/url-parser": "^4.0.0",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-body-length-node": "^4.0.0",
+				"@smithy/util-defaults-mode-browser": "^4.0.0",
+				"@smithy/util-defaults-mode-node": "^4.0.0",
+				"@smithy/util-endpoints": "^3.0.0",
+				"@smithy/util-middleware": "^4.0.0",
+				"@smithy/util-retry": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.709.0.tgz",
-			"integrity": "sha512-1w6egz17QQy661lNCRmZZlqIANEbD6g2VFAQIJbVwSiu7brg+GUns+mT1eLLLHAMQc1sL0Ds8/ybSK2SrgGgIA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/credential-provider-node": "3.709.0",
-				"@aws-sdk/middleware-host-header": "3.709.0",
-				"@aws-sdk/middleware-logger": "3.709.0",
-				"@aws-sdk/middleware-recursion-detection": "3.709.0",
-				"@aws-sdk/middleware-user-agent": "3.709.0",
-				"@aws-sdk/region-config-resolver": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@aws-sdk/util-endpoints": "3.709.0",
-				"@aws-sdk/util-user-agent-browser": "3.709.0",
-				"@aws-sdk/util-user-agent-node": "3.709.0",
-				"@smithy/config-resolver": "^3.0.13",
-				"@smithy/core": "^2.5.5",
-				"@smithy/fetch-http-handler": "^4.1.2",
-				"@smithy/hash-node": "^3.0.11",
-				"@smithy/invalid-dependency": "^3.0.11",
-				"@smithy/middleware-content-length": "^3.0.13",
-				"@smithy/middleware-endpoint": "^3.2.5",
-				"@smithy/middleware-retry": "^3.0.30",
-				"@smithy/middleware-serde": "^3.0.11",
-				"@smithy/middleware-stack": "^3.0.11",
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/node-http-handler": "^3.3.2",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/smithy-client": "^3.5.0",
-				"@smithy/types": "^3.7.2",
-				"@smithy/url-parser": "^3.0.11",
-				"@smithy/util-base64": "^3.0.0",
-				"@smithy/util-body-length-browser": "^3.0.0",
-				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.30",
-				"@smithy/util-defaults-mode-node": "^3.0.30",
-				"@smithy/util-endpoints": "^2.1.7",
-				"@smithy/util-middleware": "^3.0.11",
-				"@smithy/util-retry": "^3.0.11",
-				"@smithy/util-utf8": "^3.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.709.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true
 		},
 		"node_modules/@aws-sdk/client-sso/node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/client-sts": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.709.0.tgz",
-			"integrity": "sha512-cBAvlPg6yslXNL385UUGFPw+XY+lA9BzioNdIFkMo3fEUlTShogTtiWz4LsyLHoN6LhKojssP9DSmmWKWjCZIw==",
-			"license": "Apache-2.0",
 			"optional": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.709.0",
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/credential-provider-node": "3.709.0",
-				"@aws-sdk/middleware-host-header": "3.709.0",
-				"@aws-sdk/middleware-logger": "3.709.0",
-				"@aws-sdk/middleware-recursion-detection": "3.709.0",
-				"@aws-sdk/middleware-user-agent": "3.709.0",
-				"@aws-sdk/region-config-resolver": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@aws-sdk/util-endpoints": "3.709.0",
-				"@aws-sdk/util-user-agent-browser": "3.709.0",
-				"@aws-sdk/util-user-agent-node": "3.709.0",
-				"@smithy/config-resolver": "^3.0.13",
-				"@smithy/core": "^2.5.5",
-				"@smithy/fetch-http-handler": "^4.1.2",
-				"@smithy/hash-node": "^3.0.11",
-				"@smithy/invalid-dependency": "^3.0.11",
-				"@smithy/middleware-content-length": "^3.0.13",
-				"@smithy/middleware-endpoint": "^3.2.5",
-				"@smithy/middleware-retry": "^3.0.30",
-				"@smithy/middleware-serde": "^3.0.11",
-				"@smithy/middleware-stack": "^3.0.11",
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/node-http-handler": "^3.3.2",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/smithy-client": "^3.5.0",
-				"@smithy/types": "^3.7.2",
-				"@smithy/url-parser": "^3.0.11",
-				"@smithy/util-base64": "^3.0.0",
-				"@smithy/util-body-length-browser": "^3.0.0",
-				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.30",
-				"@smithy/util-defaults-mode-node": "^3.0.30",
-				"@smithy/util-endpoints": "^2.1.7",
-				"@smithy/util-middleware": "^3.0.11",
-				"@smithy/util-retry": "^3.0.11",
-				"@smithy/util-utf8": "^3.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sts/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true
+			"peer": true
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.709.0.tgz",
-			"integrity": "sha512-7kuSpzdOTAE026j85wq/fN9UDZ70n0OHw81vFqMWwlEFtm5IQ/MRCLKcC4HkXxTdfy1PqFlmoXxWqeBa15tujw==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.730.0.tgz",
+			"integrity": "sha512-jonKyR+2GcqbZj2WDICZS0c633keLc9qwXnePu83DfAoFXMMIMyoR/7FOGf8F3OrIdGh8KzE9VvST+nZCK9EJA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/core": "^2.5.5",
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/signature-v4": "^4.2.4",
-				"@smithy/smithy-client": "^3.5.0",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-middleware": "^3.0.11",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/core": "^3.0.0",
+				"@smithy/node-config-provider": "^4.0.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/protocol-http": "^5.0.0",
+				"@smithy/signature-v4": "^5.0.0",
+				"@smithy/smithy-client": "^4.0.0",
+				"@smithy/types": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.0",
 				"fast-xml-parser": "4.4.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/core/node_modules/tslib": {
@@ -504,23 +401,25 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.709.0.tgz",
-			"integrity": "sha512-WLzDcYo7pob8fPeeOhgVqYuV21uUKWb1RobITQzZhv0ZSToIl1KjuyRQsznC23Sot9CFl+0V2QLFFNwRiIuH7w==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.730.0.tgz",
+			"integrity": "sha512-Ynp67VkpaaFubqPrqGxLbg5XuS+QTjR7JVhZvjNO6Su4tQVKBFSfQpDIXTyggD9UVixXy4NB9cqg30uvebDeiw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/client-cognito-identity": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
@@ -528,23 +427,25 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.709.0.tgz",
-			"integrity": "sha512-ZMAp9LSikvHDFVa84dKpQmow6wsg956Um20cKuioPpX2GGreJFur7oduD+tRJT6FtIOHn+64YH+0MwiXLhsaIQ==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.730.0.tgz",
+			"integrity": "sha512-fFXgo3jBXLWqu8I07Hd96mS7RjrtpDgm3bZShm0F3lKtqDQF+hObFWq9A013SOE+RjMLVfbABhToXAYct3FcBw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
@@ -552,28 +453,30 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.709.0.tgz",
-			"integrity": "sha512-lIS7XLwCOyJnLD70f+VIRr8DNV1HPQe9oN6aguYrhoczqz7vDiVZLe3lh714cJqq9rdxzFypK5DqKHmcscMEPQ==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.730.0.tgz",
+			"integrity": "sha512-1aF3elbCzpVhWLAuV63iFElfLOqLGGTp4fkf2VAFIDO3hjshpXUQssTgIWiBwwtJYJdOSxaFrCU7u8frjr/5aQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/fetch-http-handler": "^4.1.2",
-				"@smithy/node-http-handler": "^3.3.2",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/smithy-client": "^3.5.0",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-stream": "^3.3.2",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/fetch-http-handler": "^5.0.0",
+				"@smithy/node-http-handler": "^4.0.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/protocol-http": "^5.0.0",
+				"@smithy/smithy-client": "^4.0.0",
+				"@smithy/types": "^4.0.0",
+				"@smithy/util-stream": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
@@ -581,33 +484,33 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.709.0.tgz",
-			"integrity": "sha512-qCF8IIGcPoUp+Ib3ANhbF5gElxFd+kIrtv2/1tKdvhudMANstQbMiWV0LTH47ZZR6c3as4iSrm09NZnpEoD/pA==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.730.0.tgz",
+			"integrity": "sha512-zwsxkBuQuPp06o45ATAnznHzj3+ibop/EaTytNzSv0O87Q59K/jnS/bdtv1n6bhe99XCieRNTihvtS7YklzK7A==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/credential-provider-env": "3.709.0",
-				"@aws-sdk/credential-provider-http": "3.709.0",
-				"@aws-sdk/credential-provider-process": "3.709.0",
-				"@aws-sdk/credential-provider-sso": "3.709.0",
-				"@aws-sdk/credential-provider-web-identity": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/credential-provider-imds": "^3.2.8",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/shared-ini-file-loader": "^3.1.12",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/credential-provider-env": "3.730.0",
+				"@aws-sdk/credential-provider-http": "3.730.0",
+				"@aws-sdk/credential-provider-process": "3.730.0",
+				"@aws-sdk/credential-provider-sso": "3.730.0",
+				"@aws-sdk/credential-provider-web-identity": "3.730.0",
+				"@aws-sdk/nested-clients": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/credential-provider-imds": "^4.0.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/shared-ini-file-loader": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.709.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
@@ -615,30 +518,32 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.709.0.tgz",
-			"integrity": "sha512-4HRX9KYWPSjO5O/Vg03YAsebKpvTjTvpK1n7zHYBmlLMBLxUrVsL1nNKKC5p2/7OW3RL8XR1ki3QkoV7kGRxUQ==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.730.0.tgz",
+			"integrity": "sha512-ztRjh1edY7ut2wwrj1XqHtqPY/NXEYIk5fYf04KKsp8zBi81ScVqP7C+Cst6PFKixjgLSG6RsqMx9GSAalVv0Q==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.709.0",
-				"@aws-sdk/credential-provider-http": "3.709.0",
-				"@aws-sdk/credential-provider-ini": "3.709.0",
-				"@aws-sdk/credential-provider-process": "3.709.0",
-				"@aws-sdk/credential-provider-sso": "3.709.0",
-				"@aws-sdk/credential-provider-web-identity": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/credential-provider-imds": "^3.2.8",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/shared-ini-file-loader": "^3.1.12",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/credential-provider-env": "3.730.0",
+				"@aws-sdk/credential-provider-http": "3.730.0",
+				"@aws-sdk/credential-provider-ini": "3.730.0",
+				"@aws-sdk/credential-provider-process": "3.730.0",
+				"@aws-sdk/credential-provider-sso": "3.730.0",
+				"@aws-sdk/credential-provider-web-identity": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/credential-provider-imds": "^4.0.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/shared-ini-file-loader": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
@@ -646,24 +551,26 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.709.0.tgz",
-			"integrity": "sha512-IAC+jPlGQII6jhIylHOwh3RgSobqlgL59nw2qYTURr8hMCI0Z1p5y2ee646HTVt4WeCYyzUAXfxr6YI/Vitv+Q==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.730.0.tgz",
+			"integrity": "sha512-cNKUQ81eptfZN8MlSqwUq3+5ln8u/PcY57UmLZ+npxUHanqO1akpgcpNsLpmsIkoXGbtSQrLuDUgH86lS/SWOw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/shared-ini-file-loader": "^3.1.12",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/shared-ini-file-loader": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
@@ -671,26 +578,28 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.709.0.tgz",
-			"integrity": "sha512-rYdTDOxazS2GdGScelsRK5CAkktRLCCdRjlwXaxrcW57j749hEqxcF5uTv9RD6WBwInfedcSywErNZB+hylQlg==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.730.0.tgz",
+			"integrity": "sha512-SdI2xrTbquJLMxUh5LpSwB8zfiKq3/jso53xWRgrVfeDlrSzZuyV6QghaMs3KEEjcNzwEnTfSIjGQyRXG9VrEw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.709.0",
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/token-providers": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/shared-ini-file-loader": "^3.1.12",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/client-sso": "3.730.0",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/token-providers": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/shared-ini-file-loader": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
@@ -698,26 +607,26 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.709.0.tgz",
-			"integrity": "sha512-2lbDfE0IQ6gma/7BB2JpkjW5G0wGe4AS0x80oybYAYYviJmUtIR3Cn2pXun6bnAWElt4wYKl4su7oC36rs5rNA==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.730.0.tgz",
+			"integrity": "sha512-l5vdPmvF/d890pbvv5g1GZrdjaSQkyPH/Bc8dO/ZqkWxkIP8JNgl48S2zgf4DkP3ik9K2axWO828L5RsMDQzdA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/nested-clients": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.709.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
@@ -725,35 +634,36 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.709.0.tgz",
-			"integrity": "sha512-v1OfAWhYhAz7XPtjWlQ3jDLZHCpuNrLP2bRWTEjRty8yZLN92ANehincULUGvUNszFO8rfpq2g4dmtk8XmqTzA==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.730.0.tgz",
+			"integrity": "sha512-Z25yfmHOehgIDVyY8h7GmAEbodHD2iLgNmrBBkkJXCE6d4GwDet3Qeyw4bQPPyuycBtYOUiz5Oco03+YGOEhYA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.709.0",
-				"@aws-sdk/client-sso": "3.709.0",
-				"@aws-sdk/client-sts": "3.709.0",
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.709.0",
-				"@aws-sdk/credential-provider-env": "3.709.0",
-				"@aws-sdk/credential-provider-http": "3.709.0",
-				"@aws-sdk/credential-provider-ini": "3.709.0",
-				"@aws-sdk/credential-provider-node": "3.709.0",
-				"@aws-sdk/credential-provider-process": "3.709.0",
-				"@aws-sdk/credential-provider-sso": "3.709.0",
-				"@aws-sdk/credential-provider-web-identity": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/credential-provider-imds": "^3.2.8",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/client-cognito-identity": "3.730.0",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.730.0",
+				"@aws-sdk/credential-provider-env": "3.730.0",
+				"@aws-sdk/credential-provider-http": "3.730.0",
+				"@aws-sdk/credential-provider-ini": "3.730.0",
+				"@aws-sdk/credential-provider-node": "3.730.0",
+				"@aws-sdk/credential-provider-process": "3.730.0",
+				"@aws-sdk/credential-provider-sso": "3.730.0",
+				"@aws-sdk/credential-provider-web-identity": "3.730.0",
+				"@aws-sdk/nested-clients": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/credential-provider-imds": "^4.0.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
@@ -761,22 +671,24 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.709.0.tgz",
-			"integrity": "sha512-8gQYCYAaIw4lOCd5WYdf15Y/61MgRsAnrb2eiTl+icMlUOOzl8aOl5iDwm/Idp0oHZTflwxM4XSvGXO83PRWcw==",
+			"version": "3.723.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
+			"integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/protocol-http": "^5.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
@@ -784,21 +696,23 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.709.0.tgz",
-			"integrity": "sha512-jDoGSccXv9zebnpUoisjWd5u5ZPIalrmm6TjvPzZ8UqzQt3Beiz0tnQwmxQD6KRc7ADweWP5Ntiqzbw9xpVajg==",
+			"version": "3.723.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
+			"integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
@@ -806,22 +720,24 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.709.0.tgz",
-			"integrity": "sha512-PObL/wLr4lkfbQ0yXUWaoCWu/jcwfwZzCjsUiXW/H6hW9b/00enZxmx7OhtJYaR6xmh/Lcx5wbhIoDCbzdv0tw==",
+			"version": "3.723.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
+			"integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/protocol-http": "^5.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
@@ -829,25 +745,27 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.709.0.tgz",
-			"integrity": "sha512-ooc9ZJvgkjPhi9q05XwSfNTXkEBEIfL4hleo5rQBKwHG3aTHvwOM7LLzhdX56QZVa6sorPBp6fwULuRDSqiQHw==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.730.0.tgz",
+			"integrity": "sha512-aPMZvNmf2a42B41au3bA3ODU4HfHka2nYT/SAIhhVXH1ENYfAmZo7FraFPxetKepFMCtL7j4QE6/LDucK6liIw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@aws-sdk/util-endpoints": "3.709.0",
-				"@smithy/core": "^2.5.5",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@aws-sdk/util-endpoints": "3.730.0",
+				"@smithy/core": "^3.0.0",
+				"@smithy/protocol-http": "^5.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
@@ -855,24 +773,85 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
-		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.709.0.tgz",
-			"integrity": "sha512-/NoCAMEVKAg3kBKOrNtgOfL+ECt6nrl+L7q2SyYmrcY4tVCmwuECVqewQaHc03fTnJijfKLccw0Fj+6wOCnB6w==",
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.730.0.tgz",
+			"integrity": "sha512-vilIgf1/7kre8DdE5zAQkDOwHFb/TahMn/6j2RZwFLlK7cDk91r19deSiVYnKQkupDMtOfNceNqnorM4I3PDzw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-config-provider": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.11",
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.730.0",
+				"@aws-sdk/middleware-host-header": "3.723.0",
+				"@aws-sdk/middleware-logger": "3.723.0",
+				"@aws-sdk/middleware-recursion-detection": "3.723.0",
+				"@aws-sdk/middleware-user-agent": "3.730.0",
+				"@aws-sdk/region-config-resolver": "3.723.0",
+				"@aws-sdk/types": "3.723.0",
+				"@aws-sdk/util-endpoints": "3.730.0",
+				"@aws-sdk/util-user-agent-browser": "3.723.0",
+				"@aws-sdk/util-user-agent-node": "3.730.0",
+				"@smithy/config-resolver": "^4.0.0",
+				"@smithy/core": "^3.0.0",
+				"@smithy/fetch-http-handler": "^5.0.0",
+				"@smithy/hash-node": "^4.0.0",
+				"@smithy/invalid-dependency": "^4.0.0",
+				"@smithy/middleware-content-length": "^4.0.0",
+				"@smithy/middleware-endpoint": "^4.0.0",
+				"@smithy/middleware-retry": "^4.0.0",
+				"@smithy/middleware-serde": "^4.0.0",
+				"@smithy/middleware-stack": "^4.0.0",
+				"@smithy/node-config-provider": "^4.0.0",
+				"@smithy/node-http-handler": "^4.0.0",
+				"@smithy/protocol-http": "^5.0.0",
+				"@smithy/smithy-client": "^4.0.0",
+				"@smithy/types": "^4.0.0",
+				"@smithy/url-parser": "^4.0.0",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-body-length-node": "^4.0.0",
+				"@smithy/util-defaults-mode-browser": "^4.0.0",
+				"@smithy/util-defaults-mode-node": "^4.0.0",
+				"@smithy/util-endpoints": "^3.0.0",
+				"@smithy/util-middleware": "^4.0.0",
+				"@smithy/util-retry": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.723.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
+			"integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/node-config-provider": "^4.0.0",
+				"@smithy/types": "^4.0.0",
+				"@smithy/util-config-provider": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
@@ -880,26 +859,26 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.709.0.tgz",
-			"integrity": "sha512-q5Ar6k71nci43IbULFgC8a89d/3EHpmd7HvBzqVGRcHnoPwh8eZDBfbBXKH83NGwcS1qPSRYiDbVfeWPm4/1jA==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.730.0.tgz",
+			"integrity": "sha512-BSPssGj54B/AABWXARIPOT/1ybFahM1ldlfmXy9gRmZi/afe9geWJGlFYCCt3PmqR+1Ny5XIjSfue+kMd//drQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/shared-ini-file-loader": "^3.1.12",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/nested-clients": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/property-provider": "^4.0.0",
+				"@smithy/shared-ini-file-loader": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/client-sso-oidc": "^3.709.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/token-providers/node_modules/tslib": {
@@ -907,20 +886,22 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.709.0.tgz",
-			"integrity": "sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==",
+			"version": "3.723.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
+			"integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/types/node_modules/tslib": {
@@ -928,22 +909,24 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.709.0.tgz",
-			"integrity": "sha512-Mbc7AtL5WGCTKC16IGeUTz+sjpC3ptBda2t0CcK0kMVw3THDdcSq6ZlNKO747cNqdbwUvW34oHteUiHv4/z88Q==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.730.0.tgz",
+			"integrity": "sha512-1KTFuVnk+YtLgWr6TwDiggcDqtPpOY2Cszt3r2lkXfaEAX6kHyOZi1vdvxXjPU5LsOBJem8HZ7KlkmrEi+xowg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-endpoints": "^2.1.7",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/types": "^4.0.0",
+				"@smithy/util-endpoints": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
@@ -951,19 +934,21 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.693.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.693.0.tgz",
-			"integrity": "sha512-ttrag6haJLWABhLqtg1Uf+4LgHWIMOVSYL+VYZmAp2v4PUGOwWmWQH0Zk8RM7YuQcLfH/EoR72/Yxz6A4FKcuw==",
+			"version": "3.723.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz",
+			"integrity": "sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
@@ -971,17 +956,19 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.709.0.tgz",
-			"integrity": "sha512-/rL2GasJzdTWUURCQKFldw2wqBtY4k4kCiA2tVZSKg3y4Ey7zO34SW8ebaeCE2/xoWOyLR2/etdKyphoo4Zrtg==",
+			"version": "3.723.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
+			"integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/types": "^4.0.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
@@ -991,23 +978,25 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.709.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.709.0.tgz",
-			"integrity": "sha512-trBfzSCVWy7ILgqhEXgiuM7hfRCw4F4a8IK90tjk9YL0jgoJ6eJuOp7+DfCtHJaygoBxD3cdMFkOu+lluFmGBA==",
+			"version": "3.730.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.730.0.tgz",
+			"integrity": "sha512-yBvkOAjqsDEl1va4eHNOhnFBk0iCY/DBFNyhvtTMqPF4NO+MITWpFs3J9JtZKzJlQ6x0Yb9TLQ8NhDjEISz5Ug==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "3.709.0",
-				"@aws-sdk/types": "3.709.0",
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/types": "^3.7.2",
+				"@aws-sdk/middleware-user-agent": "3.730.0",
+				"@aws-sdk/types": "3.723.0",
+				"@smithy/node-config-provider": "^4.0.0",
+				"@smithy/types": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
 				"aws-crt": ">=1.0.0"
@@ -1023,7 +1012,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@babel/cli": {
 			"version": "7.26.4",
@@ -1071,9 +1061,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-			"integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+			"integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1112,9 +1102,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz",
-			"integrity": "sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.5.tgz",
+			"integrity": "sha512-Kkm8C8uxI842AwQADxl0GbcG1rupELYLShazYEZO/2DYjhyWXJIOUVOE3tBYm6JXzUCNJOZEzqc4rCW/jsEQYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1131,14 +1121,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-			"integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+			"integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.26.3",
-				"@babel/types": "^7.26.3",
+				"@babel/parser": "^7.26.5",
+				"@babel/types": "^7.26.5",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -1161,13 +1151,13 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-			"integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+			"integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.25.9",
+				"@babel/compat-data": "^7.26.5",
 				"@babel/helper-validator-option": "^7.25.9",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
@@ -1294,9 +1284,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-			"integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+			"integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1322,15 +1312,15 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
-			"integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+			"integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-member-expression-to-functions": "^7.25.9",
 				"@babel/helper-optimise-call-expression": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
+				"@babel/traverse": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1437,13 +1427,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-			"integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+			"integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.26.3"
+				"@babel/types": "^7.26.5"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1651,13 +1641,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
-			"integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
+			"integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2071,13 +2061,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
-			"integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
+			"version": "7.26.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+			"integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2616,17 +2606,17 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.26.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-			"integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+			"integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.3",
-				"@babel/parser": "^7.26.3",
+				"@babel/generator": "^7.26.5",
+				"@babel/parser": "^7.26.5",
 				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.3",
+				"@babel/types": "^7.26.5",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2635,9 +2625,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-			"integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+			"integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3114,15 +3104,15 @@
 			}
 		},
 		"node_modules/@natlibfi/issn-verify": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/issn-verify/-/issn-verify-1.0.5.tgz",
-			"integrity": "sha512-cP9NZzvKxFJPwKUN/Xbf1MMMzo7DX4Gm7vL3WzpKAxwpl7LaHWoqTFTyxeQjbkyou4Y1kW5vlP9k/GX458fQVA==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/issn-verify/-/issn-verify-1.0.6.tgz",
+			"integrity": "sha512-OqY/VhHskveESES2IhXWibDpMgo9TMWO/mYywtvBy3xwgULqfjd/GKNGytutoGjWf0GSoQFiUlTYg37LQNu9ig==",
 			"license": "MIT"
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-9.1.1.tgz",
-			"integrity": "sha512-dDV5vEuK4mohQMJN862ugJafqD/HD6KwGiFRGLv2QvPsRUdsetoTB+C0lwvEeYRyAun+h4ZObFSPMLEhpD+npA==",
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-9.1.2.tgz",
+			"integrity": "sha512-p7xwZdcdZYg50qPOW7T4NJ9YgH5Z9nfxWrodC45WO/LmYlnPVd6l9UhH3ZsDcqxnEfQmeZpPGPVaEZYqB1r37A==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.7",
@@ -3133,13 +3123,13 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-merge": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-merge/-/marc-record-merge-7.0.7.tgz",
-			"integrity": "sha512-EzcsLClBuHIo/rRzdD2wdaNXnuAw4TrupYWYByN+h/ZYBrkbCfUo9Sj6sH9jvkRfkcFs0RrEL3yVW4t+r+Qgqw==",
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-merge/-/marc-record-merge-7.0.8.tgz",
+			"integrity": "sha512-mIc2ABMa8m6Ptt0sqbfBfLmgXl2zeWXThvAVfXMsCHy1IRt7as9/lnH8fccEPim9yF2rS62lb/qO6bG5Zj8Qyw==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.1.1",
-				"debug": "^4.3.7",
+				"@natlibfi/marc-record": "^9.1.2",
+				"debug": "^4.4.0",
 				"normalize-diacritics": "^2.14.0"
 			},
 			"engines": {
@@ -3147,13 +3137,13 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "10.1.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.1.4.tgz",
-			"integrity": "sha512-zeF/WA8ZWUbJBQBlN9WhHIIvYH+cCQIsW5Plhm8TBAjNFTrYxqujxsb2jGWDjJ/l0G8e/5BzikuizRAUu8o4UQ==",
+			"version": "10.1.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.1.5.tgz",
+			"integrity": "sha512-PNcNyGrVDty49OZzqhcjuuaRZDu2G94VLK4CbAf8h7/QbncI8Hn4CcAln/y45//9YxYtsZkGGtizl2O2p1MvVA==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.1.1",
-				"@xmldom/xmldom": "^0.9.5",
+				"@natlibfi/marc-record": "^9.1.2",
+				"@xmldom/xmldom": "^0.9.6",
 				"stream-json": "^1.9.1",
 				"xml2js": "^0.6.2",
 				"yargs": "^17.7.2"
@@ -3179,19 +3169,22 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "11.4.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.4.6.tgz",
-			"integrity": "sha512-C632RI/nlBoEecOQdNLa9M1reJ7vPpPQArdP9CFgRVd/QtcQckHt+FYBa3bk6kZhLxvd065JDJtTt7oLsrl+qQ==",
+			"version": "11.5.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.5.3.tgz",
+			"integrity": "sha512-eaYS4gQheZV/hmSz575nhOxzjOGaXjVqLJM3NWHq3amZaqT2XnwGQEGpiUTFNIeGD9IoReSI4uENYAmhSgeOzQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/issn-verify": "^1.0.4",
-				"@natlibfi/marc-record": "^9.1.1",
+				"@natlibfi/issn-verify": "^1.0.6",
+				"@natlibfi/marc-record": "^9.1.2",
+				"@natlibfi/marc-record-serializers": "^10.1.2",
 				"@natlibfi/marc-record-validate": "^8.0.12",
-				"@natlibfi/sfs-4900": "git+https://github.com/NatLibFi/sfs-4900.git",
+				"@natlibfi/melinda-commons": "^13.0.18",
+				"@natlibfi/sfs-4900": "github:NatLibFi/sfs-4900",
+				"@natlibfi/sru-client": "^6.0.17",
 				"cld3-asm": "^4.0.0",
 				"clone": "^2.1.2",
 				"debug": "^4.4.0",
-				"isbn3": "^1.2.4",
+				"isbn3": "^1.2.6",
 				"iso9_1995": "^0.0.2",
 				"langs": "^2.0.0",
 				"node-fetch": "^2.7.0",
@@ -3203,6 +3196,43 @@
 			},
 			"peerDependencies": {
 				"@natlibfi/marc-record-validate": "^8.0.12"
+			}
+		},
+		"node_modules/@natlibfi/marc-record-validators-melinda/node_modules/@natlibfi/melinda-commons": {
+			"version": "13.0.18",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.18.tgz",
+			"integrity": "sha512-Eoj23IBDkomg+7pvKm9+T4ON24aFeunbD8zZ6GdxFOXft8euu754MkYROP26FssmLZlIPeYKWy+9GZT9RoS1HQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^9.0.2",
+				"@natlibfi/marc-record-serializers": "^10.1.2",
+				"@natlibfi/sru-client": "^6.0.15",
+				"debug": "^4.3.7",
+				"deep-eql": "^5.0.2",
+				"http-status": "^1.7.4",
+				"moment": "^2.30.1",
+				"nock": "^13.5.5"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@natlibfi/marc-record-validators-melinda/node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@natlibfi/marc-record-validators-melinda/node_modules/http-status": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.8.1.tgz",
+			"integrity": "sha512-YQF7j8Qf/Rlby0IbRPiWfNZt6aeUv3K0Pi0x3crbMZN+7F8dPn5k4b3n897vpM1Vk8Mg2fhOYc9fktKEQWMy/Q==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 0.4.0"
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
@@ -3231,31 +3261,18 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.18",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.18.tgz",
-			"integrity": "sha512-Eoj23IBDkomg+7pvKm9+T4ON24aFeunbD8zZ6GdxFOXft8euu754MkYROP26FssmLZlIPeYKWy+9GZT9RoS1HQ==",
+			"version": "13.0.19-alpha.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.19-alpha.3.tgz",
+			"integrity": "sha512-jGvX6Si566NsjAeafjMzwck6UBq/LFLA3KawH/OgyJIDuRz/sbXGkGHluENvKRN6e5e/PffeoK+11HvmzBg7bg==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.0.2",
-				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.15",
-				"debug": "^4.3.7",
-				"deep-eql": "^5.0.2",
-				"http-status": "^1.7.4",
-				"moment": "^2.30.1",
-				"nock": "^13.5.5"
+				"@natlibfi/marc-record": "^9.1.2",
+				"@natlibfi/marc-record-serializers": "^10.1.5",
+				"@natlibfi/sru-client": "^6.0.17",
+				"debug": "^4.4.0"
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@natlibfi/melinda-commons/node_modules/deep-eql": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
@@ -3276,19 +3293,56 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-match-validator": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-match-validator/-/melinda-record-match-validator-2.2.4.tgz",
-			"integrity": "sha512-zafEX1OJ/08S7l2CK8IMOPeJ2YHD/BLZLZ2CgLp+absE1ACM3ZszcWbrbuTUz1DTuJfYUi0/K9GKlaebL5oG+Q==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-match-validator/-/melinda-record-match-validator-2.2.5.tgz",
+			"integrity": "sha512-rOkvsfJLof6nHdsVC1+8vpEhXOAfuoeEsZhCQtBz9ikxSQ+2A32LX7j7pNVxZNhENaRa4cKd+eh4qpV0JeuPOA==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.0.2",
-				"@natlibfi/melinda-commons": "^13.0.17",
-				"debug": "^4.3.7",
-				"isbn3": "^1.2.2",
+				"@natlibfi/marc-record": "^9.1.2",
+				"@natlibfi/melinda-commons": "^13.0.18",
+				"debug": "^4.4.0",
+				"isbn3": "^1.2.6",
 				"moment": "^2.30.1"
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@natlibfi/melinda-record-match-validator/node_modules/@natlibfi/melinda-commons": {
+			"version": "13.0.18",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.18.tgz",
+			"integrity": "sha512-Eoj23IBDkomg+7pvKm9+T4ON24aFeunbD8zZ6GdxFOXft8euu754MkYROP26FssmLZlIPeYKWy+9GZT9RoS1HQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^9.0.2",
+				"@natlibfi/marc-record-serializers": "^10.1.2",
+				"@natlibfi/sru-client": "^6.0.15",
+				"debug": "^4.3.7",
+				"deep-eql": "^5.0.2",
+				"http-status": "^1.7.4",
+				"moment": "^2.30.1",
+				"nock": "^13.5.5"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@natlibfi/melinda-record-match-validator/node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@natlibfi/melinda-record-match-validator/node_modules/http-status": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.8.1.tgz",
+			"integrity": "sha512-YQF7j8Qf/Rlby0IbRPiWfNZt6aeUv3K0Pi0x3crbMZN+7F8dPn5k4b3n897vpM1Vk8Mg2fhOYc9fktKEQWMy/Q==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 0.4.0"
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-matching": {
@@ -3312,27 +3366,101 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.2.2.tgz",
-			"integrity": "sha512-QL4OUV7hbmvpf4jLHbRtp00kuJRyZvWj3WtWWNODyFxP758+p29H+v1kcyXzj4WoBT2vCa/ITz52vRaHgYf7hQ==",
+		"node_modules/@natlibfi/melinda-record-matching/node_modules/@natlibfi/melinda-commons": {
+			"version": "13.0.18",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.18.tgz",
+			"integrity": "sha512-Eoj23IBDkomg+7pvKm9+T4ON24aFeunbD8zZ6GdxFOXft8euu754MkYROP26FssmLZlIPeYKWy+9GZT9RoS1HQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.1.1",
-				"@natlibfi/marc-record-serializers": "^10.1.4",
-				"@natlibfi/marc-record-validate": "^8.0.11",
-				"@natlibfi/marc-record-validators-melinda": "^11.4.2",
-				"@natlibfi/melinda-backend-commons": "^2.3.5",
-				"@natlibfi/melinda-commons": "^13.0.18",
-				"amqplib": "^0.10.4",
+				"@natlibfi/marc-record": "^9.0.2",
+				"@natlibfi/marc-record-serializers": "^10.1.2",
+				"@natlibfi/sru-client": "^6.0.15",
 				"debug": "^4.3.7",
-				"http-status": "^1.8.1",
+				"deep-eql": "^5.0.2",
+				"http-status": "^1.7.4",
 				"moment": "^2.30.1",
-				"mongo-sanitize": "^1.1.0",
-				"mongodb": "^4.17.2"
+				"nock": "^13.5.5"
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@natlibfi/melinda-record-matching/node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@natlibfi/melinda-record-matching/node_modules/http-status": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.8.1.tgz",
+			"integrity": "sha512-YQF7j8Qf/Rlby0IbRPiWfNZt6aeUv3K0Pi0x3crbMZN+7F8dPn5k4b3n897vpM1Vk8Mg2fhOYc9fktKEQWMy/Q==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/@natlibfi/melinda-rest-api-commons": {
+			"version": "4.2.4-alpha.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.2.4-alpha.5.tgz",
+			"integrity": "sha512-kj3B5tVN3wWnRTLC0Kp2NvLZ3kZ5RfzrF4N5ahKwaB8ki3T7aeYGWivjGnh5VAJwQDl8WP5EKOH+whvj33fxag==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^9.1.2",
+				"@natlibfi/marc-record-serializers": "^10.1.5",
+				"@natlibfi/marc-record-validate": "^8.0.12",
+				"@natlibfi/marc-record-validators-melinda": "^11.5.3",
+				"@natlibfi/melinda-backend-commons": "^2.3.6",
+				"@natlibfi/melinda-commons": "^13.0.18",
+				"amqplib": "^0.10.5",
+				"debug": "^4.4.0",
+				"http-status": "^2.1.0",
+				"moment": "^2.30.1",
+				"mongo-sanitize": "^1.1.0",
+				"mongodb": "^6.12.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@natlibfi/melinda-rest-api-commons/node_modules/@natlibfi/melinda-commons": {
+			"version": "13.0.18",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.18.tgz",
+			"integrity": "sha512-Eoj23IBDkomg+7pvKm9+T4ON24aFeunbD8zZ6GdxFOXft8euu754MkYROP26FssmLZlIPeYKWy+9GZT9RoS1HQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^9.0.2",
+				"@natlibfi/marc-record-serializers": "^10.1.2",
+				"@natlibfi/sru-client": "^6.0.15",
+				"debug": "^4.3.7",
+				"deep-eql": "^5.0.2",
+				"http-status": "^1.7.4",
+				"moment": "^2.30.1",
+				"nock": "^13.5.5"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@natlibfi/melinda-rest-api-commons/node_modules/@natlibfi/melinda-commons/node_modules/http-status": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.8.1.tgz",
+			"integrity": "sha512-YQF7j8Qf/Rlby0IbRPiWfNZt6aeUv3K0Pi0x3crbMZN+7F8dPn5k4b3n897vpM1Vk8Mg2fhOYc9fktKEQWMy/Q==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/@natlibfi/melinda-rest-api-commons/node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/@natlibfi/sfs-4900": {
@@ -3344,13 +3472,13 @@
 			}
 		},
 		"node_modules/@natlibfi/sru-client": {
-			"version": "6.0.16",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.16.tgz",
-			"integrity": "sha512-vS/sdiP25kDlnStgU97NeVzyq0fuMV7NuFmJ73HrsOqdq8/n/6h8ABNBmwqn33/BKn4LD3ShglEGweePPGfhug==",
+			"version": "6.0.17",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.17.tgz",
+			"integrity": "sha512-R4eLs0P1/DJ4Q5AtVtFkvzallY/fTDsUXxt+sfD/xquaxwM6T0igz9jEInaYjL03jTaZ+AfmGBdu0HdW4w33UQ==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.3.7",
-				"http-status": "^1.8.1",
+				"debug": "^4.4.0",
+				"http-status": "^2.1.0",
 				"node-fetch": "^2.7.0",
 				"xml2js": "^0.6.2"
 			},
@@ -3504,17 +3632,18 @@
 			}
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "3.1.9",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
-			"integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+			"integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/abort-controller/node_modules/tslib": {
@@ -3522,23 +3651,25 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "3.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
-			"integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+			"integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-config-provider": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.11",
+				"@smithy/node-config-provider": "^4.0.1",
+				"@smithy/types": "^4.1.0",
+				"@smithy/util-config-provider": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/config-resolver/node_modules/tslib": {
@@ -3546,26 +3677,28 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/core": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.5.tgz",
-			"integrity": "sha512-G8G/sDDhXA7o0bOvkc7bgai6POuSld/+XhNnWAbpQTpLv2OZPvyqQ58tLPPlz0bSNsXktldDDREIv1LczFeNEw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.1.tgz",
+			"integrity": "sha512-hhUZlBWYuh9t6ycAcN90XOyG76C1AzwxZZgaCVPMYpWqqk9uMFo7HGG5Zu2cEhCJn7DdOi5krBmlibWWWPgdsw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/middleware-serde": "^3.0.11",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-body-length-browser": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.11",
-				"@smithy/util-stream": "^3.3.2",
-				"@smithy/util-utf8": "^3.0.0",
+				"@smithy/middleware-serde": "^4.0.1",
+				"@smithy/protocol-http": "^5.0.1",
+				"@smithy/types": "^4.1.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.1",
+				"@smithy/util-stream": "^4.0.2",
+				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/core/node_modules/tslib": {
@@ -3573,23 +3706,25 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "3.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
-			"integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+			"integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/types": "^3.7.2",
-				"@smithy/url-parser": "^3.0.11",
+				"@smithy/node-config-provider": "^4.0.1",
+				"@smithy/property-provider": "^4.0.1",
+				"@smithy/types": "^4.1.0",
+				"@smithy/url-parser": "^4.0.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
@@ -3597,20 +3732,25 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.2.tgz",
-			"integrity": "sha512-R7rU7Ae3ItU4rC0c5mB2sP5mJNbCfoDc8I5XlYjIZnquyUwec7fEo78F6DA3SmgJgkU1qTMcZJuGblxZsl10ZA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+			"integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/querystring-builder": "^3.0.11",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-base64": "^3.0.0",
+				"@smithy/protocol-http": "^5.0.1",
+				"@smithy/querystring-builder": "^4.0.1",
+				"@smithy/types": "^4.1.0",
+				"@smithy/util-base64": "^4.0.0",
 				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
@@ -3618,22 +3758,24 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
-			"integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+			"integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-buffer-from": "^3.0.0",
-				"@smithy/util-utf8": "^3.0.0",
+				"@smithy/types": "^4.1.0",
+				"@smithy/util-buffer-from": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/hash-node/node_modules/tslib": {
@@ -3641,17 +3783,22 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
-			"integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+			"integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/invalid-dependency/node_modules/tslib": {
@@ -3659,19 +3806,21 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-			"integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+			"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/is-array-buffer/node_modules/tslib": {
@@ -3679,21 +3828,23 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "3.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
-			"integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+			"integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/types": "^3.7.2",
+				"@smithy/protocol-http": "^5.0.1",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/middleware-content-length/node_modules/tslib": {
@@ -3701,26 +3852,28 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.5.tgz",
-			"integrity": "sha512-VhJNs/s/lyx4weiZdXSloBgoLoS8osV0dKIain8nGmx7of3QFKu5BSdEuk1z/U8x9iwes1i+XCiNusEvuK1ijg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.2.tgz",
+			"integrity": "sha512-Z9m67CXizGpj8CF/AW/7uHqYNh1VXXOn9Ap54fenWsCa0HnT4cJuE61zqG3cBkTZJDCy0wHJphilI41co/PE5g==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^2.5.5",
-				"@smithy/middleware-serde": "^3.0.11",
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/shared-ini-file-loader": "^3.1.12",
-				"@smithy/types": "^3.7.2",
-				"@smithy/url-parser": "^3.0.11",
-				"@smithy/util-middleware": "^3.0.11",
+				"@smithy/core": "^3.1.1",
+				"@smithy/middleware-serde": "^4.0.1",
+				"@smithy/node-config-provider": "^4.0.1",
+				"@smithy/shared-ini-file-loader": "^4.0.1",
+				"@smithy/types": "^4.1.0",
+				"@smithy/url-parser": "^4.0.1",
+				"@smithy/util-middleware": "^4.0.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
@@ -3728,27 +3881,29 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "3.0.30",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.30.tgz",
-			"integrity": "sha512-6323RL2BvAR3VQpTjHpa52kH/iSHyxd/G9ohb2MkBk2Ucu+oMtRXT8yi7KTSIS9nb58aupG6nO0OlXnQOAcvmQ==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.3.tgz",
+			"integrity": "sha512-TiKwwQTwUDeDtwWW8UWURTqu7s6F3wN2pmziLU215u7bqpVT9Mk2oEvURjpRLA+5XeQhM68R5BpAGzVtomsqgA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/service-error-classification": "^3.0.11",
-				"@smithy/smithy-client": "^3.5.0",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-middleware": "^3.0.11",
-				"@smithy/util-retry": "^3.0.11",
+				"@smithy/node-config-provider": "^4.0.1",
+				"@smithy/protocol-http": "^5.0.1",
+				"@smithy/service-error-classification": "^4.0.1",
+				"@smithy/smithy-client": "^4.1.2",
+				"@smithy/types": "^4.1.0",
+				"@smithy/util-middleware": "^4.0.1",
+				"@smithy/util-retry": "^4.0.1",
 				"tslib": "^2.6.2",
 				"uuid": "^9.0.1"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/middleware-retry/node_modules/tslib": {
@@ -3756,7 +3911,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/middleware-retry/node_modules/uuid": {
 			"version": "9.0.1",
@@ -3768,22 +3924,24 @@
 			],
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
-			"integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.1.tgz",
+			"integrity": "sha512-Fh0E2SOF+S+P1+CsgKyiBInAt3o2b6Qk7YOp2W0Qx2XnfTdfMuSDKUEcnrtpxCzgKJnqXeLUZYqtThaP0VGqtA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/middleware-serde/node_modules/tslib": {
@@ -3791,20 +3949,22 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
-			"integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+			"integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/middleware-stack/node_modules/tslib": {
@@ -3812,22 +3972,24 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "3.1.12",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
-			"integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+			"integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/shared-ini-file-loader": "^3.1.12",
-				"@smithy/types": "^3.7.2",
+				"@smithy/property-provider": "^4.0.1",
+				"@smithy/shared-ini-file-loader": "^4.0.1",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/node-config-provider/node_modules/tslib": {
@@ -3835,23 +3997,25 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.2.tgz",
-			"integrity": "sha512-t4ng1DAd527vlxvOfKFYEe6/QFBcsj7WpNlWTyjorwXXcKw3XlltBGbyHfSJ24QT84nF+agDha9tNYpzmSRZPA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.2.tgz",
+			"integrity": "sha512-X66H9aah9hisLLSnGuzRYba6vckuFtGE+a5DcHLliI/YlqKrGoxhisD5XbX44KyoeRzoNlGr94eTsMVHFAzPOw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/abort-controller": "^3.1.9",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/querystring-builder": "^3.0.11",
-				"@smithy/types": "^3.7.2",
+				"@smithy/abort-controller": "^4.0.1",
+				"@smithy/protocol-http": "^5.0.1",
+				"@smithy/querystring-builder": "^4.0.1",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/node-http-handler/node_modules/tslib": {
@@ -3859,20 +4023,22 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
-			"integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+			"integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/property-provider/node_modules/tslib": {
@@ -3880,20 +4046,22 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
-			"integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+			"integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/protocol-http/node_modules/tslib": {
@@ -3901,21 +4069,23 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
-			"integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+			"integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/types": "^4.1.0",
+				"@smithy/util-uri-escape": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/querystring-builder/node_modules/tslib": {
@@ -3923,20 +4093,22 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
-			"integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+			"integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/querystring-parser/node_modules/tslib": {
@@ -3944,33 +4116,36 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
-			"integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+			"integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2"
+				"@smithy/types": "^4.1.0"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "3.1.12",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
-			"integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+			"integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
@@ -3978,26 +4153,28 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.4.tgz",
-			"integrity": "sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+			"integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/is-array-buffer": "^3.0.0",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-hex-encoding": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.11",
-				"@smithy/util-uri-escape": "^3.0.0",
-				"@smithy/util-utf8": "^3.0.0",
+				"@smithy/is-array-buffer": "^4.0.0",
+				"@smithy/protocol-http": "^5.0.1",
+				"@smithy/types": "^4.1.0",
+				"@smithy/util-hex-encoding": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.1",
+				"@smithy/util-uri-escape": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/signature-v4/node_modules/tslib": {
@@ -4005,25 +4182,27 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.5.0.tgz",
-			"integrity": "sha512-Y8FeOa7gbDfCWf7njrkoRATPa5eNLUEjlJS5z5rXatYuGkCb80LbHcu8AQR8qgAZZaNHCLyo2N+pxPsV7l+ivg==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.2.tgz",
+			"integrity": "sha512-0yApeHWBqocelHGK22UivZyShNxFbDNrgREBllGh5Ws0D0rg/yId/CJfeoKKpjbfY2ju8j6WgDUGZHYQmINZ5w==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^2.5.5",
-				"@smithy/middleware-endpoint": "^3.2.5",
-				"@smithy/middleware-stack": "^3.0.11",
-				"@smithy/protocol-http": "^4.1.8",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-stream": "^3.3.2",
+				"@smithy/core": "^3.1.1",
+				"@smithy/middleware-endpoint": "^4.0.2",
+				"@smithy/middleware-stack": "^4.0.1",
+				"@smithy/protocol-http": "^5.0.1",
+				"@smithy/types": "^4.1.0",
+				"@smithy/util-stream": "^4.0.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/smithy-client/node_modules/tslib": {
@@ -4031,19 +4210,21 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/types": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
-			"integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+			"integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/types/node_modules/tslib": {
@@ -4051,18 +4232,23 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
-			"integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+			"integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/querystring-parser": "^3.0.11",
-				"@smithy/types": "^3.7.2",
+				"@smithy/querystring-parser": "^4.0.1",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/url-parser/node_modules/tslib": {
@@ -4070,21 +4256,23 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-base64": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-			"integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+			"integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/util-buffer-from": "^3.0.0",
-				"@smithy/util-utf8": "^3.0.0",
+				"@smithy/util-buffer-from": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-base64/node_modules/tslib": {
@@ -4092,16 +4280,21 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-body-length-browser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-			"integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+			"integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
@@ -4109,19 +4302,21 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-body-length-node": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-			"integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+			"integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-body-length-node/node_modules/tslib": {
@@ -4129,20 +4324,22 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-			"integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+			"integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/is-array-buffer": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-buffer-from/node_modules/tslib": {
@@ -4150,19 +4347,21 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-config-provider": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
-			"integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+			"integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-config-provider/node_modules/tslib": {
@@ -4170,23 +4369,25 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "3.0.30",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.30.tgz",
-			"integrity": "sha512-nLuGmgfcr0gzm64pqF2UT4SGWVG8UGviAdayDlVzJPNa6Z4lqvpDzdRXmLxtOdEjVlTOEdpZ9dd3ZMMu488mzg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.3.tgz",
+			"integrity": "sha512-7c5SF1fVK0EOs+2EOf72/qF199zwJflU1d02AevwKbAUPUZyE9RUZiyJxeUmhVxfKDWdUKaaVojNiaDQgnHL9g==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/smithy-client": "^3.5.0",
-				"@smithy/types": "^3.7.2",
+				"@smithy/property-provider": "^4.0.1",
+				"@smithy/smithy-client": "^4.1.2",
+				"@smithy/types": "^4.1.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">= 10.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
@@ -4194,25 +4395,27 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "3.0.30",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.30.tgz",
-			"integrity": "sha512-OD63eWoH68vp75mYcfYyuVH+p7Li/mY4sYOROnauDrtObo1cS4uWfsy/zhOTW8F8ZPxQC1ZXZKVxoxvMGUv2Ow==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.3.tgz",
+			"integrity": "sha512-CVnD42qYD3JKgDlImZ9+On+MqJHzq9uJgPbMdeBE8c2x8VJ2kf2R3XO/yVFx+30ts5lD/GlL0eFIShY3x9ROgQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/config-resolver": "^3.0.13",
-				"@smithy/credential-provider-imds": "^3.2.8",
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/property-provider": "^3.1.11",
-				"@smithy/smithy-client": "^3.5.0",
-				"@smithy/types": "^3.7.2",
+				"@smithy/config-resolver": "^4.0.1",
+				"@smithy/credential-provider-imds": "^4.0.1",
+				"@smithy/node-config-provider": "^4.0.1",
+				"@smithy/property-provider": "^4.0.1",
+				"@smithy/smithy-client": "^4.1.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">= 10.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
@@ -4220,21 +4423,23 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
-			"integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+			"integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.12",
-				"@smithy/types": "^3.7.2",
+				"@smithy/node-config-provider": "^4.0.1",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-endpoints/node_modules/tslib": {
@@ -4242,19 +4447,21 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-hex-encoding": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-			"integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+			"integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
@@ -4262,20 +4469,22 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
-			"integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+			"integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^3.7.2",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-middleware/node_modules/tslib": {
@@ -4283,21 +4492,23 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
-			"integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+			"integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/service-error-classification": "^3.0.11",
-				"@smithy/types": "^3.7.2",
+				"@smithy/service-error-classification": "^4.0.1",
+				"@smithy/types": "^4.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-retry/node_modules/tslib": {
@@ -4305,26 +4516,28 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.2.tgz",
-			"integrity": "sha512-sInAqdiVeisUGYAv/FrXpmJ0b4WTFmciTRqzhb7wVuem9BHvhIG7tpiYHLDWrl2stOokNZpTTGqz3mzB2qFwXg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.0.2.tgz",
+			"integrity": "sha512-0eZ4G5fRzIoewtHtwaYyl8g2C+osYOT4KClXgfdNEDAgkbe2TYPqcnw4GAWabqkZCax2ihRGPe9LZnsPdIUIHA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^4.1.2",
-				"@smithy/node-http-handler": "^3.3.2",
-				"@smithy/types": "^3.7.2",
-				"@smithy/util-base64": "^3.0.0",
-				"@smithy/util-buffer-from": "^3.0.0",
-				"@smithy/util-hex-encoding": "^3.0.0",
-				"@smithy/util-utf8": "^3.0.0",
+				"@smithy/fetch-http-handler": "^5.0.1",
+				"@smithy/node-http-handler": "^4.0.2",
+				"@smithy/types": "^4.1.0",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-buffer-from": "^4.0.0",
+				"@smithy/util-hex-encoding": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-stream/node_modules/tslib": {
@@ -4332,19 +4545,21 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-uri-escape": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-			"integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+			"integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-uri-escape/node_modules/tslib": {
@@ -4352,20 +4567,22 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-			"integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+			"integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@smithy/util-buffer-from": "^3.0.0",
+				"@smithy/util-buffer-from": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/util-utf8/node_modules/tslib": {
@@ -4373,7 +4590,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -4381,15 +4599,6 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/node": {
-			"version": "22.10.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-			"integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~6.20.0"
-			}
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.8",
@@ -4411,12 +4620,11 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/whatwg-url": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-			"integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+			"integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/node": "*",
 				"@types/webidl-conversions": "*"
 			}
 		},
@@ -4787,14 +4995,14 @@
 			}
 		},
 		"node_modules/array-buffer-byte-length": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+			"integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.5",
-				"is-array-buffer": "^3.0.4"
+				"call-bound": "^1.0.3",
+				"is-array-buffer": "^3.0.5"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -4836,20 +5044,19 @@
 			}
 		},
 		"node_modules/arraybuffer.prototype.slice": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+			"integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.1",
-				"call-bind": "^1.0.5",
+				"call-bind": "^1.0.8",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.22.3",
-				"es-errors": "^1.2.1",
-				"get-intrinsic": "^1.2.3",
-				"is-array-buffer": "^3.0.4",
-				"is-shared-array-buffer": "^1.0.2"
+				"es-abstract": "^1.23.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"is-array-buffer": "^3.0.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -4966,26 +5173,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/base64-url": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.3.3.tgz",
@@ -5025,7 +5212,8 @@
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
 			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
@@ -5058,9 +5246,9 @@
 			"license": "ISC"
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-			"integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+			"version": "4.24.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
 			"dev": true,
 			"funding": [
 				{
@@ -5078,9 +5266,9 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001669",
-				"electron-to-chromium": "^1.5.41",
-				"node-releases": "^2.0.18",
+				"caniuse-lite": "^1.0.30001688",
+				"electron-to-chromium": "^1.5.73",
+				"node-releases": "^2.0.19",
 				"update-browserslist-db": "^1.1.1"
 			},
 			"bin": {
@@ -5091,39 +5279,12 @@
 			}
 		},
 		"node_modules/bson": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
-			"integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+			"version": "6.10.1",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
+			"integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
 			"license": "Apache-2.0",
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
 			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
+				"node": ">=16.20.1"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -5175,6 +5336,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
 			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.0",
@@ -5203,13 +5365,13 @@
 			}
 		},
 		"node_modules/call-bound": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.2.tgz",
-			"integrity": "sha512-0lk0PHFe/uz0vl527fG9CgdE9WdafjDbCXvBbs+LUv000TVt2Jjhqbs4Jwm8gz070w8xXyEAxrPOMullsxXeGg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+			"integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
-				"get-intrinsic": "^1.2.5"
+				"call-bind-apply-helpers": "^1.0.1",
+				"get-intrinsic": "^1.2.6"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -5239,9 +5401,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001688",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001688.tgz",
-			"integrity": "sha512-Nmqpru91cuABu/DTCXbM2NSRHzM2uVHfPnhJ/1zEAJx/ILBRVmz3pzH4N7DZqbdG0gWClsCC05Oj0mJ/1AWMbA==",
+			"version": "1.0.30001692",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
+			"integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
 			"dev": true,
 			"funding": [
 				{
@@ -5496,9 +5658,9 @@
 			"license": "MIT"
 		},
 		"node_modules/core-js": {
-			"version": "3.39.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
-			"integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+			"version": "3.40.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
+			"integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -5508,13 +5670,13 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.39.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
-			"integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
+			"version": "3.40.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
+			"integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.24.2"
+				"browserslist": "^4.24.3"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5522,9 +5684,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.39.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.39.0.tgz",
-			"integrity": "sha512-7fEcWwKI4rJinnK+wLTezeg2smbFFdSBP6E2kQZNbnzM2s1rpKQ6aaRteZSSg7FLU3P0HGGVo/gbpfanU36urg==",
+			"version": "3.40.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.40.0.tgz",
+			"integrity": "sha512-AtDzVIgRrmRKQai62yuSIN5vNiQjcJakJb4fbhVw3ehxx7Lohphvw9SGNWKhLFqSxC4ilD0g/L1huAYFQU3Q6A==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -5576,15 +5738,15 @@
 			}
 		},
 		"node_modules/data-view-buffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-			"integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+			"integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.6",
+				"call-bound": "^1.0.3",
 				"es-errors": "^1.3.0",
-				"is-data-view": "^1.0.1"
+				"is-data-view": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -5594,31 +5756,31 @@
 			}
 		},
 		"node_modules/data-view-byte-length": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-			"integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+			"integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bound": "^1.0.3",
 				"es-errors": "^1.3.0",
-				"is-data-view": "^1.0.1"
+				"is-data-view": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"url": "https://github.com/sponsors/inspect-js"
 			}
 		},
 		"node_modules/data-view-byte-offset": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
-			"integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+			"integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.6",
+				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
 				"is-data-view": "^1.0.1"
 			},
@@ -5720,6 +5882,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0",
@@ -5829,9 +5992,9 @@
 			}
 		},
 		"node_modules/domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"dom-serializer": "^2.0.0",
@@ -5855,12 +6018,12 @@
 			}
 		},
 		"node_modules/dunder-proto": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
-			"integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.0",
+				"call-bind-apply-helpers": "^1.0.1",
 				"es-errors": "^1.3.0",
 				"gopd": "^1.2.0"
 			},
@@ -5876,9 +6039,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.73",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.73.tgz",
-			"integrity": "sha512-8wGNxG9tAG5KhGd3eeA0o6ixhiNdgr0DcHWm85XPCphwZgD1lIEoi6t3VERayWao7SF7AAZTw6oARGJeVjH8Kg==",
+			"version": "1.5.83",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
+			"integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5921,58 +6084,63 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.23.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
-			"integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
+			"version": "1.23.9",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+			"integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"array-buffer-byte-length": "^1.0.1",
-				"arraybuffer.prototype.slice": "^1.0.3",
+				"array-buffer-byte-length": "^1.0.2",
+				"arraybuffer.prototype.slice": "^1.0.4",
 				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.7",
-				"data-view-buffer": "^1.0.1",
-				"data-view-byte-length": "^1.0.1",
-				"data-view-byte-offset": "^1.0.0",
-				"es-define-property": "^1.0.0",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"data-view-buffer": "^1.0.2",
+				"data-view-byte-length": "^1.0.2",
+				"data-view-byte-offset": "^1.0.1",
+				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
 				"es-object-atoms": "^1.0.0",
-				"es-set-tostringtag": "^2.0.3",
-				"es-to-primitive": "^1.2.1",
-				"function.prototype.name": "^1.1.6",
-				"get-intrinsic": "^1.2.4",
-				"get-symbol-description": "^1.0.2",
+				"es-set-tostringtag": "^2.1.0",
+				"es-to-primitive": "^1.3.0",
+				"function.prototype.name": "^1.1.8",
+				"get-intrinsic": "^1.2.7",
+				"get-proto": "^1.0.0",
+				"get-symbol-description": "^1.1.0",
 				"globalthis": "^1.0.4",
-				"gopd": "^1.0.1",
+				"gopd": "^1.2.0",
 				"has-property-descriptors": "^1.0.2",
-				"has-proto": "^1.0.3",
-				"has-symbols": "^1.0.3",
+				"has-proto": "^1.2.0",
+				"has-symbols": "^1.1.0",
 				"hasown": "^2.0.2",
-				"internal-slot": "^1.0.7",
-				"is-array-buffer": "^3.0.4",
+				"internal-slot": "^1.1.0",
+				"is-array-buffer": "^3.0.5",
 				"is-callable": "^1.2.7",
-				"is-data-view": "^1.0.1",
-				"is-negative-zero": "^2.0.3",
-				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.3",
-				"is-string": "^1.0.7",
-				"is-typed-array": "^1.1.13",
-				"is-weakref": "^1.0.2",
+				"is-data-view": "^1.0.2",
+				"is-regex": "^1.2.1",
+				"is-shared-array-buffer": "^1.0.4",
+				"is-string": "^1.1.1",
+				"is-typed-array": "^1.1.15",
+				"is-weakref": "^1.1.0",
+				"math-intrinsics": "^1.1.0",
 				"object-inspect": "^1.13.3",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.5",
+				"object.assign": "^4.1.7",
+				"own-keys": "^1.0.1",
 				"regexp.prototype.flags": "^1.5.3",
-				"safe-array-concat": "^1.1.2",
-				"safe-regex-test": "^1.0.3",
-				"string.prototype.trim": "^1.2.9",
-				"string.prototype.trimend": "^1.0.8",
+				"safe-array-concat": "^1.1.3",
+				"safe-push-apply": "^1.0.0",
+				"safe-regex-test": "^1.1.0",
+				"set-proto": "^1.0.0",
+				"string.prototype.trim": "^1.2.10",
+				"string.prototype.trimend": "^1.0.9",
 				"string.prototype.trimstart": "^1.0.8",
-				"typed-array-buffer": "^1.0.2",
-				"typed-array-byte-length": "^1.0.1",
-				"typed-array-byte-offset": "^1.0.2",
-				"typed-array-length": "^1.0.6",
-				"unbox-primitive": "^1.0.2",
-				"which-typed-array": "^1.1.15"
+				"typed-array-buffer": "^1.0.3",
+				"typed-array-byte-length": "^1.0.3",
+				"typed-array-byte-offset": "^1.0.4",
+				"typed-array-length": "^1.0.7",
+				"unbox-primitive": "^1.1.0",
+				"which-typed-array": "^1.1.18"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6007,9 +6175,9 @@
 			}
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -6019,15 +6187,16 @@
 			}
 		},
 		"node_modules/es-set-tostringtag": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"get-intrinsic": "^1.2.4",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
 				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.1"
+				"hasown": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6756,9 +6925,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6766,7 +6935,7 @@
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.4"
+				"micromatch": "^4.0.8"
 			},
 			"engines": {
 				"node": ">=8.6.0"
@@ -6802,6 +6971,7 @@
 			],
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"strnum": "^1.0.5"
 			},
@@ -6810,9 +6980,9 @@
 			}
 		},
 		"node_modules/fastq": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
+			"integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7038,16 +7208,18 @@
 			}
 		},
 		"node_modules/function.prototype.name": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+			"integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"functions-have-names": "^1.2.3"
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"functions-have-names": "^1.2.3",
+				"hasown": "^2.0.2",
+				"is-callable": "^1.2.7"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7105,21 +7277,21 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
-			"integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+			"integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
-				"dunder-proto": "^1.0.0",
 				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
 				"es-object-atoms": "^1.0.0",
 				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.0",
 				"gopd": "^1.2.0",
 				"has-symbols": "^1.1.0",
 				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.0.0"
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7138,16 +7310,29 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/get-symbol-description": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+			"integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.5",
+				"call-bound": "^1.0.3",
 				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.4"
+				"get-intrinsic": "^1.2.6"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7313,11 +7498,14 @@
 			"license": "MIT"
 		},
 		"node_modules/has-bigints": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+			"integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
 			"dev": true,
 			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -7335,6 +7523,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0"
@@ -7534,9 +7723,9 @@
 			}
 		},
 		"node_modules/http-status": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.8.1.tgz",
-			"integrity": "sha512-YQF7j8Qf/Rlby0IbRPiWfNZt6aeUv3K0Pi0x3crbMZN+7F8dPn5k4b3n897vpM1Vk8Mg2fhOYc9fktKEQWMy/Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-status/-/http-status-2.1.0.tgz",
+			"integrity": "sha512-O5kPr7AW7wYd/BBiOezTwnVAnmSNFY+J7hlZD2X5IOxVBetjcHAiTXhzj0gMrnojQlwy+UT1/Y3H3vJ3UlmvLA==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">= 0.4.0"
@@ -7553,26 +7742,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -7657,15 +7826,15 @@
 			"license": "ISC"
 		},
 		"node_modules/internal-slot": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+			"integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"hasown": "^2.0.0",
-				"side-channel": "^1.0.4"
+				"hasown": "^2.0.2",
+				"side-channel": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7676,6 +7845,8 @@
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
 			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"jsbn": "1.1.0",
 				"sprintf-js": "^1.1.3"
@@ -7688,17 +7859,20 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
 			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/is-array-buffer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+			"integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.2.1"
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"get-intrinsic": "^1.2.6"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7714,13 +7888,16 @@
 			"license": "MIT"
 		},
 		"node_modules/is-async-function": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-			"integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
+			"integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"has-tostringtag": "^1.0.0"
+				"call-bound": "^1.0.3",
+				"get-proto": "^1.0.1",
+				"has-tostringtag": "^1.0.2",
+				"safe-regex-test": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7759,13 +7936,13 @@
 			}
 		},
 		"node_modules/is-boolean-object": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.0.tgz",
-			"integrity": "sha512-kR5g0+dXf/+kXnqI+lu0URKYPKgICtHGGNCDSB10AaUFj3o/HkB3u7WfpRBJGFopxxY0oH3ux7ZsDjLtK7xqvw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+			"integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {
@@ -7789,9 +7966,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-			"integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7823,13 +8000,14 @@
 			}
 		},
 		"node_modules/is-date-object": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+			"integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"has-tostringtag": "^1.0.0"
+				"call-bound": "^1.0.2",
+				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7849,13 +8027,13 @@
 			}
 		},
 		"node_modules/is-finalizationregistry": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.0.tgz",
-			"integrity": "sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+			"integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7"
+				"call-bound": "^1.0.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7874,13 +8052,16 @@
 			}
 		},
 		"node_modules/is-generator-function": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+			"integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"has-tostringtag": "^1.0.0"
+				"call-bound": "^1.0.3",
+				"get-proto": "^1.0.0",
+				"has-tostringtag": "^1.0.2",
+				"safe-regex-test": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8088,19 +8269,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-negative-zero": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8112,13 +8280,13 @@
 			}
 		},
 		"node_modules/is-number-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.0.tgz",
-			"integrity": "sha512-KVSZV0Dunv9DTPkhXwcZ3Q+tUc9TsaE1ZwX5J2WMvsSGS6Md8TFPun5uwh0yRdrNerI6vf/tbJxqSx4c1ZI1Lw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+			"integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bound": "^1.0.3",
 				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {
@@ -8194,13 +8362,13 @@
 			}
 		},
 		"node_modules/is-shared-array-buffer": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+			"integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7"
+				"call-bound": "^1.0.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8222,13 +8390,13 @@
 			}
 		},
 		"node_modules/is-string": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.0.tgz",
-			"integrity": "sha512-PlfzajuF9vSo5wErv3MJAKD/nqf9ngAs1NFQYm16nUYFO2IzxJ2hcm+IOCg+EEopdykNNUhVq5cz35cAUxU8+g==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+			"integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bound": "^1.0.3",
 				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {
@@ -8239,15 +8407,15 @@
 			}
 		},
 		"node_modules/is-symbol": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.0.tgz",
-			"integrity": "sha512-qS8KkNNXUZ/I+nX6QT8ZS1/Yx0A444yhzdTKxCzKkNjQ9sHErBxJnJAgh+f5YhusYECEcjo4XcyH87hn6+ks0A==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+			"integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
-				"has-symbols": "^1.0.3",
-				"safe-regex-test": "^1.0.3"
+				"call-bound": "^1.0.2",
+				"has-symbols": "^1.1.0",
+				"safe-regex-test": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8257,13 +8425,13 @@
 			}
 		},
 		"node_modules/is-typed-array": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"which-typed-array": "^1.1.14"
+				"which-typed-array": "^1.1.16"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8306,27 +8474,30 @@
 			}
 		},
 		"node_modules/is-weakref": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+			"integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.2"
+				"call-bound": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-weakset": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-			"integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+			"integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
-				"get-intrinsic": "^1.2.4"
+				"call-bound": "^1.0.3",
+				"get-intrinsic": "^1.2.6"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8353,9 +8524,9 @@
 			"license": "MIT"
 		},
 		"node_modules/isbn3": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.2.4.tgz",
-			"integrity": "sha512-x+TnwQM3ipkXfvT4n9ctznJiIqG+cyD7GYTf/pn1bT04xdSQraAVTnCgQ0mMOSZO8xM5IB9DFhiklEY5pcMPjg==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.2.6.tgz",
+			"integrity": "sha512-NdV65WWyroy9treJkKkZEaXCJtfvxCHWJtduCuyHUyxFA8kwDGH6fVj+Y2lyF0k0J6TCOo5mmnf2DJ5A+PkCFQ==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",
@@ -8584,7 +8755,9 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
 			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/jsesc": {
 			"version": "3.1.0",
@@ -8640,9 +8813,9 @@
 			}
 		},
 		"node_modules/jsonschema": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-			"integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+			"integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -8831,9 +9004,9 @@
 			}
 		},
 		"node_modules/math-intrinsics": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
-			"integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -9171,81 +9344,13 @@
 			"license": "MIT"
 		},
 		"node_modules/mongodb": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
-			"integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
+			"integrity": "sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"bson": "^4.7.2",
-				"mongodb-connection-string-url": "^2.6.0",
-				"socks": "^2.7.1"
-			},
-			"engines": {
-				"node": ">=12.9.0"
-			},
-			"optionalDependencies": {
-				"@aws-sdk/credential-providers": "^3.186.0",
-				"@mongodb-js/saslprep": "^1.1.0"
-			}
-		},
-		"node_modules/mongodb-connection-string-url": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-			"integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@types/whatwg-url": "^8.2.1",
-				"whatwg-url": "^11.0.0"
-			}
-		},
-		"node_modules/mongoose": {
-			"version": "8.8.4",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.8.4.tgz",
-			"integrity": "sha512-yJbn695qCsqDO+xyPII29x2R7flzXhxCDv09mMZPSGllf0sm4jKw3E9s9uvQ9hjO6bL2xjU8KKowYqcY9eSTMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"bson": "^6.7.0",
-				"kareem": "2.6.3",
-				"mongodb": "~6.10.0",
-				"mpath": "0.9.0",
-				"mquery": "5.0.0",
-				"ms": "2.1.3",
-				"sift": "17.1.3"
-			},
-			"engines": {
-				"node": ">=16.20.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mongoose"
-			}
-		},
-		"node_modules/mongoose/node_modules/@types/whatwg-url": {
-			"version": "11.0.5",
-			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-			"integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/webidl-conversions": "*"
-			}
-		},
-		"node_modules/mongoose/node_modules/bson": {
-			"version": "6.10.1",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
-			"integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=16.20.1"
-			}
-		},
-		"node_modules/mongoose/node_modules/mongodb": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.10.0.tgz",
-			"integrity": "sha512-gP9vduuYWb9ZkDM546M+MP2qKVk5ZG2wPF63OvSRuUbqCR+11ZCAE1mOfllhlAG0wcoJY5yDL/rV3OmYEwXIzg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@mongodb-js/saslprep": "^1.1.5",
-				"bson": "^6.7.0",
+				"@mongodb-js/saslprep": "^1.1.9",
+				"bson": "^6.10.1",
 				"mongodb-connection-string-url": "^3.0.0"
 			},
 			"engines": {
@@ -9253,7 +9358,7 @@
 			},
 			"peerDependencies": {
 				"@aws-sdk/credential-providers": "^3.188.0",
-				"@mongodb-js/zstd": "^1.1.0",
+				"@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
 				"gcp-metadata": "^5.2.0",
 				"kerberos": "^2.0.1",
 				"mongodb-client-encryption": ">=6.0.0 <7",
@@ -9284,39 +9389,36 @@
 				}
 			}
 		},
-		"node_modules/mongoose/node_modules/mongodb-connection-string-url": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
-			"integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+		"node_modules/mongodb-connection-string-url": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+			"integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/whatwg-url": "^11.0.2",
-				"whatwg-url": "^13.0.0"
+				"whatwg-url": "^14.1.0 || ^13.0.0"
 			}
 		},
-		"node_modules/mongoose/node_modules/tr46": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-			"integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+		"node_modules/mongoose": {
+			"version": "8.9.5",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.5.tgz",
+			"integrity": "sha512-SPhOrgBm0nKV3b+IIHGqpUTOmgVL5Z3OO9AwkFEmvOZznXTvplbomstCnPOGAyungtRXE5pJTgKpKcZTdjeESg==",
 			"license": "MIT",
 			"dependencies": {
-				"punycode": "^2.3.0"
+				"bson": "^6.10.1",
+				"kareem": "2.6.3",
+				"mongodb": "~6.12.0",
+				"mpath": "0.9.0",
+				"mquery": "5.0.0",
+				"ms": "2.1.3",
+				"sift": "17.1.3"
 			},
 			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/mongoose/node_modules/whatwg-url": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
-			"integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "^4.1.1",
-				"webidl-conversions": "^7.0.0"
+				"node": ">=16.20.1"
 			},
-			"engines": {
-				"node": ">=16"
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mongoose"
 			}
 		},
 		"node_modules/mpath": {
@@ -9347,10 +9449,22 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "2.1.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-			"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-			"license": "MIT"
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
 		},
 		"node_modules/natural": {
 			"version": "8.0.1",
@@ -9505,9 +9619,9 @@
 			}
 		},
 		"node_modules/nodemon": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
-			"integrity": "sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==",
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+			"integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9813,15 +9927,17 @@
 			}
 		},
 		"node_modules/object.assign": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.5",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
 				"define-properties": "^1.2.1",
-				"has-symbols": "^1.0.3",
+				"es-object-atoms": "^1.0.0",
+				"has-symbols": "^1.1.0",
 				"object-keys": "^1.1.1"
 			},
 			"engines": {
@@ -9897,6 +10013,24 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/own-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+			"integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-intrinsic": "^1.2.6",
+				"object-keys": "^1.1.1",
+				"safe-push-apply": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/p-limit": {
@@ -10419,12 +10553,12 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
-			"integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.0.6"
+				"side-channel": "^1.1.0"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -10515,20 +10649,20 @@
 			}
 		},
 		"node_modules/reflect.getprototypeof": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.8.tgz",
-			"integrity": "sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+			"integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"define-properties": "^1.2.1",
-				"dunder-proto": "^1.0.0",
-				"es-abstract": "^1.23.5",
+				"es-abstract": "^1.23.9",
 				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.4",
-				"gopd": "^1.2.0",
-				"which-builtin-type": "^1.2.0"
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.7",
+				"get-proto": "^1.0.1",
+				"which-builtin-type": "^1.2.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -10574,15 +10708,17 @@
 			}
 		},
 		"node_modules/regexp.prototype.flags": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
-			"integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+			"integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bind": "^1.0.8",
 				"define-properties": "^1.2.1",
 				"es-errors": "^1.3.0",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
 				"set-function-name": "^2.0.2"
 			},
 			"engines": {
@@ -10685,18 +10821,21 @@
 			"license": "MIT"
 		},
 		"node_modules/resolve": {
-			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"version": "1.22.10",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.13.0",
+				"is-core-module": "^2.16.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
 			"bin": {
 				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -10790,16 +10929,33 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"license": "MIT"
 		},
-		"node_modules/safe-regex-test": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+		"node_modules/safe-push-apply": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+			"integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.6",
 				"es-errors": "^1.3.0",
-				"is-regex": "^1.1.4"
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-regex-test": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.2.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -10878,6 +11034,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.1.4",
@@ -10902,6 +11059,21 @@
 				"es-errors": "^1.3.0",
 				"functions-have-names": "^1.2.3",
 				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-proto": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+			"integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -11078,6 +11250,8 @@
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
@@ -11088,6 +11262,8 @@
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
 			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
@@ -11396,7 +11572,8 @@
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
 			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -11507,15 +11684,15 @@
 			}
 		},
 		"node_modules/tr46": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-			"integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+			"integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
 			"license": "MIT",
 			"dependencies": {
-				"punycode": "^2.1.1"
+				"punycode": "^2.3.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/triple-beam": {
@@ -11595,32 +11772,32 @@
 			}
 		},
 		"node_modules/typed-array-buffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bound": "^1.0.3",
 				"es-errors": "^1.3.0",
-				"is-typed-array": "^1.1.13"
+				"is-typed-array": "^1.1.14"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/typed-array-byte-length": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+			"integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bind": "^1.0.8",
 				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-proto": "^1.0.3",
-				"is-typed-array": "^1.1.13"
+				"gopd": "^1.2.0",
+				"has-proto": "^1.2.0",
+				"is-typed-array": "^1.1.14"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -11630,19 +11807,19 @@
 			}
 		},
 		"node_modules/typed-array-byte-offset": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.3.tgz",
-			"integrity": "sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+			"integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.7",
+				"call-bind": "^1.0.8",
 				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-proto": "^1.0.3",
-				"is-typed-array": "^1.1.13",
-				"reflect.getprototypeof": "^1.0.6"
+				"gopd": "^1.2.0",
+				"has-proto": "^1.2.0",
+				"is-typed-array": "^1.1.15",
+				"reflect.getprototypeof": "^1.0.9"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -11683,9 +11860,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-			"integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -11698,16 +11875,19 @@
 			}
 		},
 		"node_modules/unbox-primitive": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+			"integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.2",
+				"call-bound": "^1.0.3",
 				"has-bigints": "^1.0.2",
-				"has-symbols": "^1.0.3",
-				"which-boxed-primitive": "^1.0.2"
+				"has-symbols": "^1.1.0",
+				"which-boxed-primitive": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -11724,12 +11904,6 @@
 			"version": "1.13.7",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
 			"integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
-			"license": "MIT"
-		},
-		"node_modules/undici-types": {
-			"version": "6.20.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
 			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
@@ -11812,9 +11986,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+			"integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
 			"dev": true,
 			"funding": [
 				{
@@ -11833,7 +12007,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"escalade": "^3.2.0",
-				"picocolors": "^1.1.0"
+				"picocolors": "^1.1.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -11875,9 +12049,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
-			"integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+			"integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -11922,16 +12096,16 @@
 			}
 		},
 		"node_modules/whatwg-url": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-			"integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.0.tgz",
+			"integrity": "sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==",
 			"license": "MIT",
 			"dependencies": {
-				"tr46": "^3.0.0",
+				"tr46": "^5.0.0",
 				"webidl-conversions": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/which": {
@@ -11951,17 +12125,17 @@
 			}
 		},
 		"node_modules/which-boxed-primitive": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.0.tgz",
-			"integrity": "sha512-Ei7Miu/AXe2JJ4iNF5j/UphAgRoma4trE6PtisM09bPygb3egMH3YLW/befsWb1A1AxvNSFidOFTB18XtnIIng==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+			"integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-bigint": "^1.1.0",
-				"is-boolean-object": "^1.2.0",
-				"is-number-object": "^1.1.0",
-				"is-string": "^1.1.0",
-				"is-symbol": "^1.1.0"
+				"is-boolean-object": "^1.2.1",
+				"is-number-object": "^1.1.1",
+				"is-string": "^1.1.1",
+				"is-symbol": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -11971,25 +12145,25 @@
 			}
 		},
 		"node_modules/which-builtin-type": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.0.tgz",
-			"integrity": "sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+			"integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bound": "^1.0.2",
 				"function.prototype.name": "^1.1.6",
 				"has-tostringtag": "^1.0.2",
 				"is-async-function": "^2.0.0",
-				"is-date-object": "^1.0.5",
+				"is-date-object": "^1.1.0",
 				"is-finalizationregistry": "^1.1.0",
 				"is-generator-function": "^1.0.10",
-				"is-regex": "^1.1.4",
+				"is-regex": "^1.2.1",
 				"is-weakref": "^1.0.2",
 				"isarray": "^2.0.5",
-				"which-boxed-primitive": "^1.0.2",
+				"which-boxed-primitive": "^1.1.0",
 				"which-collection": "^1.0.2",
-				"which-typed-array": "^1.1.15"
+				"which-typed-array": "^1.1.16"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -12025,16 +12199,17 @@
 			"license": "ISC"
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.16.tgz",
-			"integrity": "sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+			"integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
 				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
+				"gopd": "^1.2.0",
 				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@natlibfi/marc-record-serializers": "^10.1.5",
 				"@natlibfi/melinda-backend-commons": "^2.3.6",
 				"@natlibfi/melinda-commons": "^13.0.19",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.3",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.4",
 				"@natlibfi/melinda-record-match-validator": "^2.2.5",
 				"@natlibfi/melinda-record-matching": "^4.3.4",
 				"@natlibfi/melinda-rest-api-commons": "^4.2.4-alpha.5",
@@ -3239,17 +3239,17 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.3.3.tgz",
-			"integrity": "sha512-umr0QzH7P1A2e/UC9ZVYigVsLfsbVmKKduC3j6N5v5j+cgMqEu4cGXgTnuIk+7oqjRphPyjrLU/hVrD1fDwf6w==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.3.4.tgz",
+			"integrity": "sha512-MteXQp+I3ej7SUOmYfX6k7aFBrg6iI1viBL/CCdLwGiPrXAv0M8DJ5CLE/7iAxYEqpz1rODqCFg3YNzEeuLBbg==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.1.1",
-				"@natlibfi/marc-record-merge": "^7.0.7",
+				"@natlibfi/marc-record": "^9.1.2",
+				"@natlibfi/marc-record-merge": "^7.0.8",
 				"@natlibfi/marc-record-validate": "^8.0.12",
-				"@natlibfi/marc-record-validators-melinda": "^11.4.6",
+				"@natlibfi/marc-record-validators-melinda": "^11.5.3",
 				"debug": "^4.4.0",
-				"isbn3": "^1.2.4"
+				"isbn3": "^1.2.6"
 			},
 			"engines": {
 				"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@natlibfi/marc-record-merge": "^7.0.8",
 		"@natlibfi/marc-record-serializers": "^10.1.5",
 		"@natlibfi/melinda-backend-commons": "^2.3.6",
-		"@natlibfi/melinda-commons": "^13.0.19-alpha.3",
+		"@natlibfi/melinda-commons": "^13.0.19",
 		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.3",
 		"@natlibfi/melinda-record-match-validator": "^2.2.5",
 		"@natlibfi/melinda-record-matching": "^4.3.4",
@@ -65,7 +65,7 @@
 		"chai": "^4.5.0",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.57.1",
-		"mocha": "^11.0.1",
+		"mocha": "^11.1.0",
 		"nodemon": "^3.1.9",
 		"nyc": "^17.1.0"
 	},

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "3.7.5-alpha.1",
+	"version": "3.7.5-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "3.7.4",
+	"version": "3.7.5-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -35,20 +35,20 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "^7.26.0",
-		"@natlibfi/marc-record": "^9.1.1",
-		"@natlibfi/marc-record-merge": "^7.0.7",
-		"@natlibfi/marc-record-serializers": "^10.1.4",
+		"@natlibfi/marc-record": "^9.1.2",
+		"@natlibfi/marc-record-merge": "^7.0.8",
+		"@natlibfi/marc-record-serializers": "^10.1.5",
 		"@natlibfi/melinda-backend-commons": "^2.3.6",
-		"@natlibfi/melinda-commons": "^13.0.18",
+		"@natlibfi/melinda-commons": "^13.0.19-alpha.3",
 		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.3",
-		"@natlibfi/melinda-record-match-validator": "^2.2.4",
+		"@natlibfi/melinda-record-match-validator": "^2.2.5",
 		"@natlibfi/melinda-record-matching": "^4.3.4",
-		"@natlibfi/melinda-rest-api-commons": "^4.2.2",
-		"@natlibfi/sru-client": "^6.0.16",
+		"@natlibfi/melinda-rest-api-commons": "^4.2.4-alpha.5",
+		"@natlibfi/sru-client": "^6.0.17",
 		"debug": "^4.4.0",
 		"deep-eql": "^4.1.4",
 		"deep-object-diff": "^1.1.9",
-		"http-status": "^1.8.1"
+		"http-status": "^2.1.0"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.26.4",
@@ -66,8 +66,11 @@
 		"cross-env": "^7.0.3",
 		"eslint": "^8.57.1",
 		"mocha": "^11.0.1",
-		"nodemon": "^3.1.7",
+		"nodemon": "^3.1.9",
 		"nyc": "^17.1.0"
+	},
+	"overrides": {
+		"nanoid": "^3.3.8"
 	},
 	"eslintConfig": {
 		"extends": "@natlibfi/melinda-backend"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@natlibfi/marc-record-serializers": "^10.1.5",
 		"@natlibfi/melinda-backend-commons": "^2.3.6",
 		"@natlibfi/melinda-commons": "^13.0.19",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.3",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.4",
 		"@natlibfi/melinda-record-match-validator": "^2.2.5",
 		"@natlibfi/melinda-record-matching": "^4.3.4",
 		"@natlibfi/melinda-rest-api-commons": "^4.2.4-alpha.5",

--- a/src/app.js
+++ b/src/app.js
@@ -23,6 +23,7 @@ export default async function ({
   const toMarcRecords = await toMarcRecordFactory({amqpOperator, mongoOperator, mongoLogOperator, splitterOptions});
 
   logger.info(`Started Melinda-rest-api-validator: ${pollRequest ? 'PRIORITY' : 'BULK'} for ${recordType} records`);
+  logger.debug(`Poll wait time: ${pollWaitTime} is ${typeof pollWaitTime}`);
 
   const server = await initCheck();
 

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ const debug = createDebugLogger('@natlibfi/melinda-rest-api-validator:config');
 
 // Poll variables
 export const pollRequest = readEnvironmentVariable('POLL_REQUEST', {defaultValue: 0, format: v => parseBoolean(v)});
-export const pollWaitTime = readEnvironmentVariable('POLL_WAIT_TIME', {defaultValue: 1000});
+export const pollWaitTime = parseInt(readEnvironmentVariable('POLL_WAIT_TIME', {defaultValue: 1000}), 10);
 
 // Amqp variables to priority
 export const amqpUrl = readEnvironmentVariable('AMQP_URL', {defaultValue: 'amqp://127.0.0.1:5672/'});


### PR DESCRIPTION
* Bump mongoose from 8.8.4 to 8.9.5 (#500)

* Bump the production-dependencies group with 6 updates (#499)

| Package | From | To |
| --- | --- | --- |
| [@natlibfi/marc-record](https://github.com/natlibfi/marc-record-js) | `9.1.1` | `9.1.2` | 
| [@natlibfi/marc-record-merge](https://github.com/natlibfi/marc-record-merge-js) | `7.0.7` | `7.0.8` | 
| [@natlibfi/marc-record-serializers](https://github.com/natlibfi/marc-record-serializers) | `10.1.4` | `10.1.5` |
 | [@natlibfi/melinda-record-match-validator](https://github.com/NatLibFi/melinda-record-match-validator) | `2.2.4` | `2.2.5` | 
| [@natlibfi/melinda-rest-api-commons](https://github.com/natlibfi/melinda-rest-api-commons) | `4.2.2` | `4.2.3` | 
| [@natlibfi/sru-client](https://github.com/natlibfi/sru-client-js) | `6.0.16` | `6.0.17` |

* Bump nodemon from 3.1.7 to 3.1.9 in the development-dependencies group (#498)

* Add nanoid v3.3.8 override

* Update http-status v2.1.0

* Update commons & rest-api-commons

* Set pollWaitTime to number

* Node-tests: add v23

* 3.7.5-alpha.1