### PR TITLE
Merge updates (MRA-849, MELKEHITYS-3147) ; Dependency Update (#512)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,6 @@ Queue-item schema examle for a bulk job queueItem:
 
 ## License and copyright
 
-Copyright (c) 2020-2024 **University Of Helsinki (The National Library Of Finland)**
+Copyright (c) 2020-2025 **University Of Helsinki (The National Library Of Finland)**
 
 This project's source code is licensed under the terms of **MIT** or any later version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.7.5-alpha.2",
+	"version": "3.7.5-alpha.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.7.5-alpha.2",
+			"version": "3.7.5-alpha.3",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.26.0",
-				"@natlibfi/marc-record": "^9.1.2",
+				"@babel/runtime": "^7.26.7",
+				"@natlibfi/marc-record": "^9.1.3",
 				"@natlibfi/marc-record-merge": "^7.0.8",
 				"@natlibfi/marc-record-serializers": "^10.1.5",
 				"@natlibfi/melinda-backend-commons": "^2.3.6",
 				"@natlibfi/melinda-commons": "^13.0.19",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.4",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.6",
 				"@natlibfi/melinda-record-match-validator": "^2.2.5",
 				"@natlibfi/melinda-record-matching": "^4.3.4",
 				"@natlibfi/melinda-rest-api-commons": "^4.2.4-alpha.5",
@@ -27,10 +27,10 @@
 			},
 			"devDependencies": {
 				"@babel/cli": "^7.26.4",
-				"@babel/core": "^7.26.0",
+				"@babel/core": "^7.26.7",
 				"@babel/node": "^7.26.0",
 				"@babel/plugin-transform-runtime": "^7.25.9",
-				"@babel/preset-env": "^7.26.0",
+				"@babel/preset-env": "^7.26.7",
 				"@babel/register": "^7.25.9",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
 				"@natlibfi/fixugen": "^2.0.12",
@@ -75,945 +75,6 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
-		},
-		"node_modules/@aws-crypto/sha256-browser": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-crypto/sha256-js": "^5.2.0",
-				"@aws-crypto/supports-web-crypto": "^5.2.0",
-				"@aws-crypto/util": "^5.2.0",
-				"@aws-sdk/types": "^3.222.0",
-				"@aws-sdk/util-locate-window": "^3.0.0",
-				"@smithy/util-utf8": "^2.0.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-crypto/sha256-js": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-crypto/util": "^5.2.0",
-				"@aws-sdk/types": "^3.222.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-crypto/supports-web-crypto": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-crypto/util": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "^3.222.0",
-				"@smithy/util-utf8": "^2.0.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.730.0.tgz",
-			"integrity": "sha512-iJt2pL6RqWg7R3pja1WfcC2+oTjwaKFYndNE9oUQqyc6RN24XWUtGy9JnWqTUOy8jYzaP2eoF00fGeasSBX+Dw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/credential-provider-node": "3.730.0",
-				"@aws-sdk/middleware-host-header": "3.723.0",
-				"@aws-sdk/middleware-logger": "3.723.0",
-				"@aws-sdk/middleware-recursion-detection": "3.723.0",
-				"@aws-sdk/middleware-user-agent": "3.730.0",
-				"@aws-sdk/region-config-resolver": "3.723.0",
-				"@aws-sdk/types": "3.723.0",
-				"@aws-sdk/util-endpoints": "3.730.0",
-				"@aws-sdk/util-user-agent-browser": "3.723.0",
-				"@aws-sdk/util-user-agent-node": "3.730.0",
-				"@smithy/config-resolver": "^4.0.0",
-				"@smithy/core": "^3.0.0",
-				"@smithy/fetch-http-handler": "^5.0.0",
-				"@smithy/hash-node": "^4.0.0",
-				"@smithy/invalid-dependency": "^4.0.0",
-				"@smithy/middleware-content-length": "^4.0.0",
-				"@smithy/middleware-endpoint": "^4.0.0",
-				"@smithy/middleware-retry": "^4.0.0",
-				"@smithy/middleware-serde": "^4.0.0",
-				"@smithy/middleware-stack": "^4.0.0",
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/node-http-handler": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/smithy-client": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/url-parser": "^4.0.0",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.0",
-				"@smithy/util-defaults-mode-node": "^4.0.0",
-				"@smithy/util-endpoints": "^3.0.0",
-				"@smithy/util-middleware": "^4.0.0",
-				"@smithy/util-retry": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.730.0.tgz",
-			"integrity": "sha512-mI8kqkSuVlZklewEmN7jcbBMyVODBld3MsTjCKSl5ztduuPX69JD7nXLnWWPkw1PX4aGTO24AEoRMGNxntoXUg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/middleware-host-header": "3.723.0",
-				"@aws-sdk/middleware-logger": "3.723.0",
-				"@aws-sdk/middleware-recursion-detection": "3.723.0",
-				"@aws-sdk/middleware-user-agent": "3.730.0",
-				"@aws-sdk/region-config-resolver": "3.723.0",
-				"@aws-sdk/types": "3.723.0",
-				"@aws-sdk/util-endpoints": "3.730.0",
-				"@aws-sdk/util-user-agent-browser": "3.723.0",
-				"@aws-sdk/util-user-agent-node": "3.730.0",
-				"@smithy/config-resolver": "^4.0.0",
-				"@smithy/core": "^3.0.0",
-				"@smithy/fetch-http-handler": "^5.0.0",
-				"@smithy/hash-node": "^4.0.0",
-				"@smithy/invalid-dependency": "^4.0.0",
-				"@smithy/middleware-content-length": "^4.0.0",
-				"@smithy/middleware-endpoint": "^4.0.0",
-				"@smithy/middleware-retry": "^4.0.0",
-				"@smithy/middleware-serde": "^4.0.0",
-				"@smithy/middleware-stack": "^4.0.0",
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/node-http-handler": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/smithy-client": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/url-parser": "^4.0.0",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.0",
-				"@smithy/util-defaults-mode-node": "^4.0.0",
-				"@smithy/util-endpoints": "^3.0.0",
-				"@smithy/util-middleware": "^4.0.0",
-				"@smithy/util-retry": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/core": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.730.0.tgz",
-			"integrity": "sha512-jonKyR+2GcqbZj2WDICZS0c633keLc9qwXnePu83DfAoFXMMIMyoR/7FOGf8F3OrIdGh8KzE9VvST+nZCK9EJA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/core": "^3.0.0",
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/signature-v4": "^5.0.0",
-				"@smithy/smithy-client": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.0",
-				"fast-xml-parser": "4.4.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/core/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.730.0.tgz",
-			"integrity": "sha512-Ynp67VkpaaFubqPrqGxLbg5XuS+QTjR7JVhZvjNO6Su4tQVKBFSfQpDIXTyggD9UVixXy4NB9cqg30uvebDeiw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.730.0.tgz",
-			"integrity": "sha512-fFXgo3jBXLWqu8I07Hd96mS7RjrtpDgm3bZShm0F3lKtqDQF+hObFWq9A013SOE+RjMLVfbABhToXAYct3FcBw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.730.0.tgz",
-			"integrity": "sha512-1aF3elbCzpVhWLAuV63iFElfLOqLGGTp4fkf2VAFIDO3hjshpXUQssTgIWiBwwtJYJdOSxaFrCU7u8frjr/5aQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/fetch-http-handler": "^5.0.0",
-				"@smithy/node-http-handler": "^4.0.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/smithy-client": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/util-stream": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.730.0.tgz",
-			"integrity": "sha512-zwsxkBuQuPp06o45ATAnznHzj3+ibop/EaTytNzSv0O87Q59K/jnS/bdtv1n6bhe99XCieRNTihvtS7YklzK7A==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/credential-provider-env": "3.730.0",
-				"@aws-sdk/credential-provider-http": "3.730.0",
-				"@aws-sdk/credential-provider-process": "3.730.0",
-				"@aws-sdk/credential-provider-sso": "3.730.0",
-				"@aws-sdk/credential-provider-web-identity": "3.730.0",
-				"@aws-sdk/nested-clients": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/credential-provider-imds": "^4.0.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/shared-ini-file-loader": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.730.0.tgz",
-			"integrity": "sha512-ztRjh1edY7ut2wwrj1XqHtqPY/NXEYIk5fYf04KKsp8zBi81ScVqP7C+Cst6PFKixjgLSG6RsqMx9GSAalVv0Q==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.730.0",
-				"@aws-sdk/credential-provider-http": "3.730.0",
-				"@aws-sdk/credential-provider-ini": "3.730.0",
-				"@aws-sdk/credential-provider-process": "3.730.0",
-				"@aws-sdk/credential-provider-sso": "3.730.0",
-				"@aws-sdk/credential-provider-web-identity": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/credential-provider-imds": "^4.0.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/shared-ini-file-loader": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.730.0.tgz",
-			"integrity": "sha512-cNKUQ81eptfZN8MlSqwUq3+5ln8u/PcY57UmLZ+npxUHanqO1akpgcpNsLpmsIkoXGbtSQrLuDUgH86lS/SWOw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/shared-ini-file-loader": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.730.0.tgz",
-			"integrity": "sha512-SdI2xrTbquJLMxUh5LpSwB8zfiKq3/jso53xWRgrVfeDlrSzZuyV6QghaMs3KEEjcNzwEnTfSIjGQyRXG9VrEw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/client-sso": "3.730.0",
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/token-providers": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/shared-ini-file-loader": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.730.0.tgz",
-			"integrity": "sha512-l5vdPmvF/d890pbvv5g1GZrdjaSQkyPH/Bc8dO/ZqkWxkIP8JNgl48S2zgf4DkP3ik9K2axWO828L5RsMDQzdA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/nested-clients": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.730.0.tgz",
-			"integrity": "sha512-Z25yfmHOehgIDVyY8h7GmAEbodHD2iLgNmrBBkkJXCE6d4GwDet3Qeyw4bQPPyuycBtYOUiz5Oco03+YGOEhYA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.730.0",
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.730.0",
-				"@aws-sdk/credential-provider-env": "3.730.0",
-				"@aws-sdk/credential-provider-http": "3.730.0",
-				"@aws-sdk/credential-provider-ini": "3.730.0",
-				"@aws-sdk/credential-provider-node": "3.730.0",
-				"@aws-sdk/credential-provider-process": "3.730.0",
-				"@aws-sdk/credential-provider-sso": "3.730.0",
-				"@aws-sdk/credential-provider-web-identity": "3.730.0",
-				"@aws-sdk/nested-clients": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/credential-provider-imds": "^4.0.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.723.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
-			"integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.723.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
-			"integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.723.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
-			"integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.730.0.tgz",
-			"integrity": "sha512-aPMZvNmf2a42B41au3bA3ODU4HfHka2nYT/SAIhhVXH1ENYfAmZo7FraFPxetKepFMCtL7j4QE6/LDucK6liIw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@aws-sdk/util-endpoints": "3.730.0",
-				"@smithy/core": "^3.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.730.0.tgz",
-			"integrity": "sha512-vilIgf1/7kre8DdE5zAQkDOwHFb/TahMn/6j2RZwFLlK7cDk91r19deSiVYnKQkupDMtOfNceNqnorM4I3PDzw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.730.0",
-				"@aws-sdk/middleware-host-header": "3.723.0",
-				"@aws-sdk/middleware-logger": "3.723.0",
-				"@aws-sdk/middleware-recursion-detection": "3.723.0",
-				"@aws-sdk/middleware-user-agent": "3.730.0",
-				"@aws-sdk/region-config-resolver": "3.723.0",
-				"@aws-sdk/types": "3.723.0",
-				"@aws-sdk/util-endpoints": "3.730.0",
-				"@aws-sdk/util-user-agent-browser": "3.723.0",
-				"@aws-sdk/util-user-agent-node": "3.730.0",
-				"@smithy/config-resolver": "^4.0.0",
-				"@smithy/core": "^3.0.0",
-				"@smithy/fetch-http-handler": "^5.0.0",
-				"@smithy/hash-node": "^4.0.0",
-				"@smithy/invalid-dependency": "^4.0.0",
-				"@smithy/middleware-content-length": "^4.0.0",
-				"@smithy/middleware-endpoint": "^4.0.0",
-				"@smithy/middleware-retry": "^4.0.0",
-				"@smithy/middleware-serde": "^4.0.0",
-				"@smithy/middleware-stack": "^4.0.0",
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/node-http-handler": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/smithy-client": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/url-parser": "^4.0.0",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.0",
-				"@smithy/util-defaults-mode-node": "^4.0.0",
-				"@smithy/util-endpoints": "^3.0.0",
-				"@smithy/util-middleware": "^4.0.0",
-				"@smithy/util-retry": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.723.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
-			"integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/util-config-provider": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.730.0.tgz",
-			"integrity": "sha512-BSPssGj54B/AABWXARIPOT/1ybFahM1ldlfmXy9gRmZi/afe9geWJGlFYCCt3PmqR+1Ny5XIjSfue+kMd//drQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/nested-clients": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/shared-ini-file-loader": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/token-providers/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/types": {
-			"version": "3.723.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-			"integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/types/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.730.0.tgz",
-			"integrity": "sha512-1KTFuVnk+YtLgWr6TwDiggcDqtPpOY2Cszt3r2lkXfaEAX6kHyOZi1vdvxXjPU5LsOBJem8HZ7KlkmrEi+xowg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/util-endpoints": "^3.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.723.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz",
-			"integrity": "sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.723.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
-			"integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/types": "^4.0.0",
-				"bowser": "^2.11.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.730.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.730.0.tgz",
-			"integrity": "sha512-yBvkOAjqsDEl1va4eHNOhnFBk0iCY/DBFNyhvtTMqPF4NO+MITWpFs3J9JtZKzJlQ6x0Yb9TLQ8NhDjEISz5Ug==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "3.730.0",
-				"@aws-sdk/types": "3.723.0",
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"aws-crt": ">=1.0.0"
-			},
-			"peerDependenciesMeta": {
-				"aws-crt": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/@babel/cli": {
 			"version": "7.26.4",
@@ -1071,22 +132,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-			"integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+			"version": "7.26.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
+			"integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.26.0",
-				"@babel/generator": "^7.26.0",
-				"@babel/helper-compilation-targets": "^7.25.9",
+				"@babel/code-frame": "^7.26.2",
+				"@babel/generator": "^7.26.5",
+				"@babel/helper-compilation-targets": "^7.26.5",
 				"@babel/helper-module-transforms": "^7.26.0",
-				"@babel/helpers": "^7.26.0",
-				"@babel/parser": "^7.26.0",
+				"@babel/helpers": "^7.26.7",
+				"@babel/parser": "^7.26.7",
 				"@babel/template": "^7.25.9",
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.26.0",
+				"@babel/traverse": "^7.26.7",
+				"@babel/types": "^7.26.7",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -1389,14 +450,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-			"integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+			"version": "7.26.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
+			"integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.0"
+				"@babel/types": "^7.26.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1427,13 +488,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
-			"integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+			"version": "7.26.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
+			"integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.26.5"
+				"@babel/types": "^7.26.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -2364,13 +1425,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typeof-symbol": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
-			"integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
+			"version": "7.26.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.26.7.tgz",
+			"integrity": "sha512-jfoTXXZTgGg36BmhqT3cAYK5qkmqvJpvNrPhaK/52Vgjhw4Rq29s9UqpWWV0D6yuRmgiFH/BUVlkl96zJWqnaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2447,15 +1508,15 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
-			"integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
+			"version": "7.26.7",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.7.tgz",
+			"integrity": "sha512-Ycg2tnXwixaXOVb29rana8HNPgLVBof8qqtNQ9LE22IoyZboQbGSxI6ZySMdW3K5nAe6gu35IaJefUJflhUFTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.26.0",
-				"@babel/helper-compilation-targets": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/compat-data": "^7.26.5",
+				"@babel/helper-compilation-targets": "^7.26.5",
+				"@babel/helper-plugin-utils": "^7.26.5",
 				"@babel/helper-validator-option": "^7.25.9",
 				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
 				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
@@ -2469,7 +1530,7 @@
 				"@babel/plugin-transform-arrow-functions": "^7.25.9",
 				"@babel/plugin-transform-async-generator-functions": "^7.25.9",
 				"@babel/plugin-transform-async-to-generator": "^7.25.9",
-				"@babel/plugin-transform-block-scoped-functions": "^7.25.9",
+				"@babel/plugin-transform-block-scoped-functions": "^7.26.5",
 				"@babel/plugin-transform-block-scoping": "^7.25.9",
 				"@babel/plugin-transform-class-properties": "^7.25.9",
 				"@babel/plugin-transform-class-static-block": "^7.26.0",
@@ -2480,7 +1541,7 @@
 				"@babel/plugin-transform-duplicate-keys": "^7.25.9",
 				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
 				"@babel/plugin-transform-dynamic-import": "^7.25.9",
-				"@babel/plugin-transform-exponentiation-operator": "^7.25.9",
+				"@babel/plugin-transform-exponentiation-operator": "^7.26.3",
 				"@babel/plugin-transform-export-namespace-from": "^7.25.9",
 				"@babel/plugin-transform-for-of": "^7.25.9",
 				"@babel/plugin-transform-function-name": "^7.25.9",
@@ -2489,12 +1550,12 @@
 				"@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
 				"@babel/plugin-transform-member-expression-literals": "^7.25.9",
 				"@babel/plugin-transform-modules-amd": "^7.25.9",
-				"@babel/plugin-transform-modules-commonjs": "^7.25.9",
+				"@babel/plugin-transform-modules-commonjs": "^7.26.3",
 				"@babel/plugin-transform-modules-systemjs": "^7.25.9",
 				"@babel/plugin-transform-modules-umd": "^7.25.9",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
 				"@babel/plugin-transform-new-target": "^7.25.9",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.25.9",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
 				"@babel/plugin-transform-numeric-separator": "^7.25.9",
 				"@babel/plugin-transform-object-rest-spread": "^7.25.9",
 				"@babel/plugin-transform-object-super": "^7.25.9",
@@ -2511,7 +1572,7 @@
 				"@babel/plugin-transform-spread": "^7.25.9",
 				"@babel/plugin-transform-sticky-regex": "^7.25.9",
 				"@babel/plugin-transform-template-literals": "^7.25.9",
-				"@babel/plugin-transform-typeof-symbol": "^7.25.9",
+				"@babel/plugin-transform-typeof-symbol": "^7.26.7",
 				"@babel/plugin-transform-unicode-escapes": "^7.25.9",
 				"@babel/plugin-transform-unicode-property-regex": "^7.25.9",
 				"@babel/plugin-transform-unicode-regex": "^7.25.9",
@@ -2566,9 +1627,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-			"integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+			"version": "7.26.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
+			"integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
 			"license": "MIT",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -2578,9 +1639,9 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.0.tgz",
-			"integrity": "sha512-YXHu5lN8kJCb1LOb9PgV6pvak43X2h4HvRApcN5SdWeaItQOzfn1hgP6jasD6KWQyJDBxrVmA9o9OivlnNJK/w==",
+			"version": "7.26.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.7.tgz",
+			"integrity": "sha512-55gRV8vGrCIYZnaQHQrD92Lo/hYE3Sj5tmbuf0hhHR7sj2CWhEhHU89hbq+UVDXvFG1zUVXJhUkEq1eAfqXtFw==",
 			"license": "MIT",
 			"dependencies": {
 				"core-js-pure": "^3.30.2",
@@ -2606,17 +1667,17 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
-			"integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
+			"version": "7.26.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
+			"integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
 				"@babel/generator": "^7.26.5",
-				"@babel/parser": "^7.26.5",
+				"@babel/parser": "^7.26.7",
 				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.5",
+				"@babel/types": "^7.26.7",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2625,9 +1686,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
-			"integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+			"version": "7.26.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
+			"integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3110,13 +2171,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-9.1.2.tgz",
-			"integrity": "sha512-p7xwZdcdZYg50qPOW7T4NJ9YgH5Z9nfxWrodC45WO/LmYlnPVd6l9UhH3ZsDcqxnEfQmeZpPGPVaEZYqB1r37A==",
+			"version": "9.1.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-9.1.3.tgz",
+			"integrity": "sha512-gOwa/3B9nHOuSnRWfVoz9oKw4pIW0t6fbrBL4kfpFnqEQ9un/jxIdzaqRivGgWVthztcqKVS+GnuS/L6C9oqHA==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.3.7",
-				"jsonschema": "^1.4.1"
+				"debug": "^4.4.0",
+				"jsonschema": "^1.5.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3169,22 +2230,22 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "11.5.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.5.3.tgz",
-			"integrity": "sha512-eaYS4gQheZV/hmSz575nhOxzjOGaXjVqLJM3NWHq3amZaqT2XnwGQEGpiUTFNIeGD9IoReSI4uENYAmhSgeOzQ==",
+			"version": "11.5.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.5.4.tgz",
+			"integrity": "sha512-bUN0wfFAP/4UEr0YCeR6gex2wej2yXGlCCUeAiQ8uwJLETB0ZWXA5yul3cZAu2vrXF/ppeRu4h/WeAks9iD9pQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/issn-verify": "^1.0.6",
-				"@natlibfi/marc-record": "^9.1.2",
+				"@natlibfi/marc-record": "^9.1.3",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
 				"@natlibfi/marc-record-validate": "^8.0.12",
-				"@natlibfi/melinda-commons": "^13.0.18",
+				"@natlibfi/melinda-commons": "^13.0.19",
 				"@natlibfi/sfs-4900": "github:NatLibFi/sfs-4900",
 				"@natlibfi/sru-client": "^6.0.17",
 				"cld3-asm": "^4.0.0",
 				"clone": "^2.1.2",
 				"debug": "^4.4.0",
-				"isbn3": "^1.2.6",
+				"isbn3": "^1.2.7",
 				"iso9_1995": "^0.0.2",
 				"langs": "^2.0.0",
 				"node-fetch": "^2.7.0",
@@ -3239,17 +2300,17 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.3.4.tgz",
-			"integrity": "sha512-MteXQp+I3ej7SUOmYfX6k7aFBrg6iI1viBL/CCdLwGiPrXAv0M8DJ5CLE/7iAxYEqpz1rODqCFg3YNzEeuLBbg==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.3.6.tgz",
+			"integrity": "sha512-pz9g0SX+T6wUll3iFk+EMfEN/ZSBmr7lDuVnx57o53S3Jlcn+5UAJt28UUiR6LTg65JsEAdoQ8/UZdfIM7CtZw==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.1.2",
+				"@natlibfi/marc-record": "^9.1.3",
 				"@natlibfi/marc-record-merge": "^7.0.8",
 				"@natlibfi/marc-record-validate": "^8.0.12",
-				"@natlibfi/marc-record-validators-melinda": "^11.5.3",
+				"@natlibfi/marc-record-validators-melinda": "^11.5.4",
 				"debug": "^4.4.0",
-				"isbn3": "^1.2.6"
+				"isbn3": "^1.2.7"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3483,968 +2544,6 @@
 				"url": "https://ko-fi.com/killymxi"
 			}
 		},
-		"node_modules/@smithy/abort-controller": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-			"integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/abort-controller/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/config-resolver": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-			"integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-config-provider": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/config-resolver/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/core": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.1.tgz",
-			"integrity": "sha512-hhUZlBWYuh9t6ycAcN90XOyG76C1AzwxZZgaCVPMYpWqqk9uMFo7HGG5Zu2cEhCJn7DdOi5krBmlibWWWPgdsw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/middleware-serde": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-stream": "^4.0.2",
-				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/core/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-			"integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-			"integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/querystring-builder": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-base64": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/hash-node": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-			"integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-buffer-from": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/hash-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-			"integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/invalid-dependency/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-			"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/is-array-buffer/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-			"integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-content-length/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.2.tgz",
-			"integrity": "sha512-Z9m67CXizGpj8CF/AW/7uHqYNh1VXXOn9Ap54fenWsCa0HnT4cJuE61zqG3cBkTZJDCy0wHJphilI41co/PE5g==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/core": "^3.1.1",
-				"@smithy/middleware-serde": "^4.0.1",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
-				"@smithy/util-middleware": "^4.0.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/middleware-retry": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.3.tgz",
-			"integrity": "sha512-TiKwwQTwUDeDtwWW8UWURTqu7s6F3wN2pmziLU215u7bqpVT9Mk2oEvURjpRLA+5XeQhM68R5BpAGzVtomsqgA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/service-error-classification": "^4.0.1",
-				"@smithy/smithy-client": "^4.1.2",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-retry": "^4.0.1",
-				"tslib": "^2.6.2",
-				"uuid": "^9.0.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-retry/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/middleware-retry/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/@smithy/middleware-serde": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.1.tgz",
-			"integrity": "sha512-Fh0E2SOF+S+P1+CsgKyiBInAt3o2b6Qk7YOp2W0Qx2XnfTdfMuSDKUEcnrtpxCzgKJnqXeLUZYqtThaP0VGqtA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-serde/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/middleware-stack": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-			"integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-stack/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/node-config-provider": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-			"integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/node-config-provider/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/node-http-handler": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.2.tgz",
-			"integrity": "sha512-X66H9aah9hisLLSnGuzRYba6vckuFtGE+a5DcHLliI/YlqKrGoxhisD5XbX44KyoeRzoNlGr94eTsMVHFAzPOw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/abort-controller": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/querystring-builder": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/node-http-handler/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/property-provider": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-			"integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/property-provider/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/protocol-http": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-			"integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/protocol-http/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/querystring-builder": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-			"integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-uri-escape": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-builder/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/querystring-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-			"integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-parser/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/service-error-classification": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-			"integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-			"integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/signature-v4": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-			"integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/is-array-buffer": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-hex-encoding": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-uri-escape": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/signature-v4/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/smithy-client": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.2.tgz",
-			"integrity": "sha512-0yApeHWBqocelHGK22UivZyShNxFbDNrgREBllGh5Ws0D0rg/yId/CJfeoKKpjbfY2ju8j6WgDUGZHYQmINZ5w==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/core": "^3.1.1",
-				"@smithy/middleware-endpoint": "^4.0.2",
-				"@smithy/middleware-stack": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-stream": "^4.0.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/smithy-client/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/types/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/url-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-			"integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/querystring-parser": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/url-parser/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-base64": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-			"integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/util-buffer-from": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-base64/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-			"integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
-			"integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-			"integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/is-array-buffer": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-buffer-from/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-config-provider": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-			"integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-config-provider/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.3.tgz",
-			"integrity": "sha512-7c5SF1fVK0EOs+2EOf72/qF199zwJflU1d02AevwKbAUPUZyE9RUZiyJxeUmhVxfKDWdUKaaVojNiaDQgnHL9g==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/smithy-client": "^4.1.2",
-				"@smithy/types": "^4.1.0",
-				"bowser": "^2.11.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.3.tgz",
-			"integrity": "sha512-CVnD42qYD3JKgDlImZ9+On+MqJHzq9uJgPbMdeBE8c2x8VJ2kf2R3XO/yVFx+30ts5lD/GlL0eFIShY3x9ROgQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/config-resolver": "^4.0.1",
-				"@smithy/credential-provider-imds": "^4.0.1",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/smithy-client": "^4.1.2",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-endpoints": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-			"integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-endpoints/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-			"integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-middleware": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-			"integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-middleware/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-retry": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-			"integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/service-error-classification": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-retry/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-stream": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.0.2.tgz",
-			"integrity": "sha512-0eZ4G5fRzIoewtHtwaYyl8g2C+osYOT4KClXgfdNEDAgkbe2TYPqcnw4GAWabqkZCax2ihRGPe9LZnsPdIUIHA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.0.1",
-				"@smithy/node-http-handler": "^4.0.2",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-buffer-from": "^4.0.0",
-				"@smithy/util-hex-encoding": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-stream/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-			"integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-uri-escape/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@smithy/util-utf8": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-			"integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@smithy/util-buffer-from": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-utf8/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4570,9 +2669,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4609,9 +2708,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4653,16 +2752,16 @@
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
-			"integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.9.6",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.6.tgz",
-			"integrity": "sha512-Su4xcxR0CPGwlDHNmVP09fqET9YxbyDXHaSob6JlBH7L6reTYaeim6zbk9o08UarO0L5GTRo3uzl0D+9lSxmvw==",
+			"version": "0.9.7",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.7.tgz",
+			"integrity": "sha512-syvR8iIJjpTZ/stv7l89UAViwGFh6lbheeOaqSxkYx9YNmIVvPTRH+CT/fpykFtUx5N+8eSMDRvggF9J8GEPzQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.6"
@@ -4936,6 +3035,16 @@
 				"lodash": "^4.17.14"
 			}
 		},
+		"node_modules/async-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+			"integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5059,14 +3168,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/bowser": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -5131,9 +3232,9 @@
 			}
 		},
 		"node_modules/bson": {
-			"version": "6.10.1",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
-			"integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.2.tgz",
+			"integrity": "sha512-5afhLTjqDSA3akH56E+/2J6kTDuSIlBxyXPdQslj9hcIgOUE378xdOfZvC/9q3LifJNI6KR/juZ+d0NRNYBwXg==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.20.1"
@@ -5253,9 +3354,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001692",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
-			"integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
+			"version": "1.0.30001697",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+			"integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5891,9 +3992,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.83",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
-			"integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
+			"version": "1.5.91",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
+			"integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6338,9 +4439,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-functional/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -6807,34 +4908,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-xml-parser": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/naturalintelligence"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"strnum": "^1.0.5"
-			},
-			"bin": {
-				"fxparser": "src/cli/cli.js"
-			}
-		},
 		"node_modules/fastq": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-			"integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+			"integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6961,13 +5038,19 @@
 			}
 		},
 		"node_modules/for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
+			"integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-callable": "^1.1.3"
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/foreground-child": {
@@ -7613,9 +5696,9 @@
 			"license": "ISC"
 		},
 		"node_modules/import-fresh": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7692,29 +5775,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/ip-address": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/ip-address/node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -7740,12 +5800,13 @@
 			"license": "MIT"
 		},
 		"node_modules/is-async-function": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
-			"integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+			"integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"async-function": "^1.0.0",
 				"call-bound": "^1.0.3",
 				"get-proto": "^1.0.1",
 				"has-tostringtag": "^1.0.2",
@@ -8096,9 +6157,9 @@
 			}
 		},
 		"node_modules/is-immutable-type/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -8326,13 +6387,13 @@
 			}
 		},
 		"node_modules/is-weakref": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
-			"integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+			"integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bound": "^1.0.2"
+				"call-bound": "^1.0.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8376,9 +6437,9 @@
 			"license": "MIT"
 		},
 		"node_modules/isbn3": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.2.6.tgz",
-			"integrity": "sha512-NdV65WWyroy9treJkKkZEaXCJtfvxCHWJtduCuyHUyxFA8kwDGH6fVj+Y2lyF0k0J6TCOo5mmnf2DJ5A+PkCFQ==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.2.7.tgz",
+			"integrity": "sha512-nr5K3ojSDQ7K8cjYPmftSrygm5x8av26V83B7nnjZe25rOvnv6gVs1eZbZQCtVDof06H86BbqSTt+xjV2PS5Hw==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",
@@ -8453,9 +6514,9 @@
 			}
 		},
 		"node_modules/istanbul-lib-instrument/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -8525,9 +6586,9 @@
 			}
 		},
 		"node_modules/istanbul-lib-report/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -8602,14 +6663,6 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
-		},
-		"node_modules/jsbn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/jsesc": {
 			"version": "3.1.0",
@@ -9159,9 +7212,9 @@
 			"license": "MIT"
 		},
 		"node_modules/mongodb": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
-			"integrity": "sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==",
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.0.tgz",
+			"integrity": "sha512-KeESYR5TEaFxOuwRqkOm3XOsMqCSkdeDMjaW5u2nuKfX7rqaofp7JQGoi7sVqQcNJTKuveNbzZtWMstb8ABP6Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.1.9",
@@ -9215,9 +7268,9 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "8.9.5",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.5.tgz",
-			"integrity": "sha512-SPhOrgBm0nKV3b+IIHGqpUTOmgVL5Z3OO9AwkFEmvOZznXTvplbomstCnPOGAyungtRXE5pJTgKpKcZTdjeESg==",
+			"version": "8.9.6",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.6.tgz",
+			"integrity": "sha512-ipLvXwNPVuuuq5H3lnSD0lpaRH3DlCoC6emnMVJvweTwxU29uxDJWxMsNpERDQt8JMvYF1HGVuTK+Id2BlQLCA==",
 			"license": "MIT",
 			"dependencies": {
 				"bson": "^6.10.1",
@@ -9234,6 +7287,52 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/mongoose"
+			}
+		},
+		"node_modules/mongoose/node_modules/mongodb": {
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
+			"integrity": "sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@mongodb-js/saslprep": "^1.1.9",
+				"bson": "^6.10.1",
+				"mongodb-connection-string-url": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.20.1"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-providers": "^3.188.0",
+				"@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+				"gcp-metadata": "^5.2.0",
+				"kerberos": "^2.0.1",
+				"mongodb-client-encryption": ">=6.0.0 <7",
+				"snappy": "^7.2.2",
+				"socks": "^2.7.1"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/credential-providers": {
+					"optional": true
+				},
+				"@mongodb-js/zstd": {
+					"optional": true
+				},
+				"gcp-metadata": {
+					"optional": true
+				},
+				"kerberos": {
+					"optional": true
+				},
+				"mongodb-client-encryption": {
+					"optional": true
+				},
+				"snappy": {
+					"optional": true
+				},
+				"socks": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/mpath": {
@@ -9411,9 +7510,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nodemailer": {
-			"version": "6.9.16",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.16.tgz",
-			"integrity": "sha512-psAuZdTIRN08HKVd/E8ObdV6NO7NTBY3KsC30F7M4H1OnmLCUNaS56FpYxyb26zWLSyYF9Ozch9KYHhHegsiOQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
+			"integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
@@ -9483,9 +7582,9 @@
 			}
 		},
 		"node_modules/nodemon/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -11015,9 +9114,9 @@
 			}
 		},
 		"node_modules/simple-update-notifier/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -11035,34 +9134,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/smart-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"ip-address": "^9.0.5",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
-				"npm": ">= 3.0.0"
 			}
 		},
 		"node_modules/source-map": {
@@ -11358,14 +9429,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/strnum": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "3.7.5-alpha.2",
+	"version": "3.7.5-alpha.3",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -34,13 +34,13 @@
 		"dev": "NODE_ENV=development cross-env nodemon"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.26.0",
-		"@natlibfi/marc-record": "^9.1.2",
+		"@babel/runtime": "^7.26.7",
+		"@natlibfi/marc-record": "^9.1.3",
 		"@natlibfi/marc-record-merge": "^7.0.8",
 		"@natlibfi/marc-record-serializers": "^10.1.5",
 		"@natlibfi/melinda-backend-commons": "^2.3.6",
 		"@natlibfi/melinda-commons": "^13.0.19",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.4",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.6",
 		"@natlibfi/melinda-record-match-validator": "^2.2.5",
 		"@natlibfi/melinda-record-matching": "^4.3.4",
 		"@natlibfi/melinda-rest-api-commons": "^4.2.4-alpha.5",
@@ -52,10 +52,10 @@
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.26.4",
-		"@babel/core": "^7.26.0",
+		"@babel/core": "^7.26.7",
 		"@babel/node": "^7.26.0",
 		"@babel/plugin-transform-runtime": "^7.25.9",
-		"@babel/preset-env": "^7.26.0",
+		"@babel/preset-env": "^7.26.7",
 		"@babel/register": "^7.25.9",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
 		"@natlibfi/fixugen": "^2.0.12",


### PR DESCRIPTION
* Merge updates by updating [@natlibfi/melinda-marc-record-merge-reducers] to 2.3.6  ** Update [@natlibfi/marc-record-validators-melinda to 11.5.4  ** Handle non-all-capital variants o f594 states 'Ei vastaanotettu.' and 'Ei ilmesty.' (MELKEHITYS-3147) ** Handle 'designer' as a work-level contributor (MRA-849)

* Bump the production-dependencies group across 1 directory with 3 updates (#511)

Bumps the production-dependencies group with 3 updates in the / directory: [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime), [@natlibfi/marc-record](https://github.com/natlibfi/marc-record-js) and [@natlibfi/melinda-marc-record-merge-reducers](https://github.com/natlibfi/melinda-marc-record-merge-reducers-js).

* Bump the development-dependencies group with 2 updates (#510)

Bumps the development-dependencies group with 2 updates: [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) and [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env).

* Update deps

* Update copyright year

* 3.7.5-alpha.3