### PR TITLE
MELKEHITYS-3155 ; Dependency Update (#517)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.7.5",
+	"version": "3.7.6-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.7.5",
+			"version": "3.7.6-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.26.7",
@@ -15,7 +15,7 @@
 				"@natlibfi/marc-record-serializers": "^10.1.5",
 				"@natlibfi/melinda-backend-commons": "^2.3.6",
 				"@natlibfi/melinda-commons": "^13.0.19",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.6",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.7",
 				"@natlibfi/melinda-record-match-validator": "^2.2.5",
 				"@natlibfi/melinda-record-matching": "^4.3.4",
 				"@natlibfi/melinda-rest-api-commons": "^4.2.4-alpha.5",
@@ -27,10 +27,10 @@
 			},
 			"devDependencies": {
 				"@babel/cli": "^7.26.4",
-				"@babel/core": "^7.26.7",
+				"@babel/core": "^7.26.8",
 				"@babel/node": "^7.26.0",
-				"@babel/plugin-transform-runtime": "^7.25.9",
-				"@babel/preset-env": "^7.26.7",
+				"@babel/plugin-transform-runtime": "^7.26.8",
+				"@babel/preset-env": "^7.26.8",
 				"@babel/register": "^7.25.9",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
 				"@natlibfi/fixugen": "^2.0.12",
@@ -122,9 +122,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
-			"integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+			"integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -132,22 +132,23 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
-			"integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.8.tgz",
+			"integrity": "sha512-l+lkXCHS6tQEc5oUpK28xBOZ6+HwaH7YwoYQbLFiYb4nS2/l1tKnZEtEWkD0GuiYdvArf9qBS0XlQGXzPMsNqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.5",
+				"@babel/generator": "^7.26.8",
 				"@babel/helper-compilation-targets": "^7.26.5",
 				"@babel/helper-module-transforms": "^7.26.0",
 				"@babel/helpers": "^7.26.7",
-				"@babel/parser": "^7.26.7",
-				"@babel/template": "^7.25.9",
-				"@babel/traverse": "^7.26.7",
-				"@babel/types": "^7.26.7",
+				"@babel/parser": "^7.26.8",
+				"@babel/template": "^7.26.8",
+				"@babel/traverse": "^7.26.8",
+				"@babel/types": "^7.26.8",
+				"@types/gensync": "^1.0.0",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -163,9 +164,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.5.tgz",
-			"integrity": "sha512-Kkm8C8uxI842AwQADxl0GbcG1rupELYLShazYEZO/2DYjhyWXJIOUVOE3tBYm6JXzUCNJOZEzqc4rCW/jsEQYQ==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.8.tgz",
+			"integrity": "sha512-3tBctaHRW6xSub26z7n8uyOTwwUsCdvIug/oxBH9n6yCO5hMj2vwDJAo7RbBMKrM7P+W2j61zLKviJQFGOYKMg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -182,14 +183,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
-			"integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.8.tgz",
+			"integrity": "sha512-ef383X5++iZHWAXX0SXQR6ZyQhw/0KtTkrTz61WXRhFM6dhpHulO/RJz79L8S6ugZHJkOOkUrUdxgdF2YiPFnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.26.5",
-				"@babel/types": "^7.26.5",
+				"@babel/parser": "^7.26.8",
+				"@babel/types": "^7.26.8",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -488,13 +489,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
-			"integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
+			"integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.26.7"
+				"@babel/types": "^7.26.8"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -666,15 +667,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
-			"integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
+			"integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.26.5",
 				"@babel/helper-remap-async-to-generator": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
+				"@babel/traverse": "^7.26.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1339,14 +1340,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.9.tgz",
-			"integrity": "sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.26.8.tgz",
+			"integrity": "sha512-H0jlQxFMI0Q8SyGPsj9pO3ygVQRxPkIGytsL3m1Zqca8KrCPpMlvh+e2dxknqdfS8LFwBw+PpiYPD9qy/FPQpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.26.5",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
 				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
@@ -1409,13 +1410,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-template-literals": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
-			"integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
+			"integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1508,13 +1509,13 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.7.tgz",
-			"integrity": "sha512-Ycg2tnXwixaXOVb29rana8HNPgLVBof8qqtNQ9LE22IoyZboQbGSxI6ZySMdW3K5nAe6gu35IaJefUJflhUFTQ==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.8.tgz",
+			"integrity": "sha512-um7Sy+2THd697S4zJEfv/U5MHGJzkN2xhtsR3T/SWRbVSic62nbISh51VVfU9JiO/L/Z97QczHTaFVkOU8IzNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.26.5",
+				"@babel/compat-data": "^7.26.8",
 				"@babel/helper-compilation-targets": "^7.26.5",
 				"@babel/helper-plugin-utils": "^7.26.5",
 				"@babel/helper-validator-option": "^7.25.9",
@@ -1528,7 +1529,7 @@
 				"@babel/plugin-syntax-import-attributes": "^7.26.0",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.25.9",
-				"@babel/plugin-transform-async-generator-functions": "^7.25.9",
+				"@babel/plugin-transform-async-generator-functions": "^7.26.8",
 				"@babel/plugin-transform-async-to-generator": "^7.25.9",
 				"@babel/plugin-transform-block-scoped-functions": "^7.26.5",
 				"@babel/plugin-transform-block-scoping": "^7.25.9",
@@ -1571,7 +1572,7 @@
 				"@babel/plugin-transform-shorthand-properties": "^7.25.9",
 				"@babel/plugin-transform-spread": "^7.25.9",
 				"@babel/plugin-transform-sticky-regex": "^7.25.9",
-				"@babel/plugin-transform-template-literals": "^7.25.9",
+				"@babel/plugin-transform-template-literals": "^7.26.8",
 				"@babel/plugin-transform-typeof-symbol": "^7.26.7",
 				"@babel/plugin-transform-unicode-escapes": "^7.25.9",
 				"@babel/plugin-transform-unicode-property-regex": "^7.25.9",
@@ -1579,9 +1580,9 @@
 				"@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.6",
+				"babel-plugin-polyfill-corejs3": "^0.11.0",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
-				"core-js-compat": "^3.38.1",
+				"core-js-compat": "^3.40.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1589,6 +1590,20 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+			"integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.6.3",
+				"core-js-compat": "^3.40.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/@babel/preset-modules": {
@@ -1652,32 +1667,32 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-			"integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.8.tgz",
+			"integrity": "sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.25.9",
-				"@babel/parser": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/code-frame": "^7.26.2",
+				"@babel/parser": "^7.26.8",
+				"@babel/types": "^7.26.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
-			"integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.8.tgz",
+			"integrity": "sha512-nic9tRkjYH0oB2dzr/JoGIm+4Q6SuYeLEiIiZDwBscRMYFJ+tMAz98fuel9ZnbXViA2I0HVSSRRK8DW5fjXStA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.5",
-				"@babel/parser": "^7.26.7",
-				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.7",
+				"@babel/generator": "^7.26.8",
+				"@babel/parser": "^7.26.8",
+				"@babel/template": "^7.26.8",
+				"@babel/types": "^7.26.8",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -1686,9 +1701,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
-			"integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
+			"integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2114,9 +2129,9 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
-			"integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
+			"integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
 			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
@@ -2300,9 +2315,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.3.6.tgz",
-			"integrity": "sha512-pz9g0SX+T6wUll3iFk+EMfEN/ZSBmr7lDuVnx57o53S3Jlcn+5UAJt28UUiR6LTg65JsEAdoQ8/UZdfIM7CtZw==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-2.3.7.tgz",
+			"integrity": "sha512-M6AvS5P02Cr9qK1D6VL3twXg6DVjFjWIhASnNtLKr5f5Xa8PCKZe8qdvbWf0B3FH1Pl9bq1MPiD0c+TjeasX7Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^9.1.3",
@@ -2354,17 +2369,17 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "4.2.4-alpha.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.2.4-alpha.5.tgz",
-			"integrity": "sha512-kj3B5tVN3wWnRTLC0Kp2NvLZ3kZ5RfzrF4N5ahKwaB8ki3T7aeYGWivjGnh5VAJwQDl8WP5EKOH+whvj33fxag==",
+			"version": "4.2.4-alpha.7",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.2.4-alpha.7.tgz",
+			"integrity": "sha512-QM+H8kXwayWs2Dc5YnYeYj5OnPLaImLfGTZg1FnHf/JlC+RtN5HlGJOKYv8DHA86/OLq6es7NJ/IucqY4okPPg==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.1.2",
+				"@natlibfi/marc-record": "^9.1.3",
 				"@natlibfi/marc-record-serializers": "^10.1.5",
 				"@natlibfi/marc-record-validate": "^8.0.12",
 				"@natlibfi/marc-record-validators-melinda": "^11.5.3",
 				"@natlibfi/melinda-backend-commons": "^2.3.6",
-				"@natlibfi/melinda-commons": "^13.0.18",
+				"@natlibfi/melinda-commons": "^13.0.19",
 				"amqplib": "^0.10.5",
 				"debug": "^4.4.0",
 				"http-status": "^2.1.0",
@@ -2543,6 +2558,13 @@
 			"funding": {
 				"url": "https://ko-fi.com/killymxi"
 			}
+		},
+		"node_modules/@types/gensync": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.4.tgz",
+			"integrity": "sha512-C3YYeRQWp2fmq9OryX+FoDy8nXS6scQ7dPptD8LnFDAUNcKWJjXQKDNJD3HVm+kOUsXhTOkpi69vI4EuAr95bA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -3354,9 +3376,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001697",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
-			"integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
+			"version": "1.0.30001699",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
+			"integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
 			"dev": true,
 			"funding": [
 				{
@@ -3992,9 +4014,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.91",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
-			"integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
+			"version": "1.5.97",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.97.tgz",
+			"integrity": "sha512-HKLtaH02augM7ZOdYRuO19rWDeY+QSJ1VxnXFa/XDFLf07HvM90pALIJFgrO+UVaajI3+aJMMpojoUTLZyQ7JQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5038,9 +5060,9 @@
 			}
 		},
 		"node_modules/for-each": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
-			"integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5849,13 +5871,13 @@
 			}
 		},
 		"node_modules/is-boolean-object": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-			"integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+			"integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bound": "^1.0.2",
+				"call-bound": "^1.0.3",
 				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {
@@ -7268,14 +7290,14 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "8.9.6",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.6.tgz",
-			"integrity": "sha512-ipLvXwNPVuuuq5H3lnSD0lpaRH3DlCoC6emnMVJvweTwxU29uxDJWxMsNpERDQt8JMvYF1HGVuTK+Id2BlQLCA==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.10.0.tgz",
+			"integrity": "sha512-nLhk3Qrv6q/HpD2k1O7kbBqsq+/kmKpdv5KJ+LLhQlII3e1p/SSLoLP6jMuSiU6+iLK7zFw4T1niAk3mA3QVug==",
 			"license": "MIT",
 			"dependencies": {
 				"bson": "^6.10.1",
 				"kareem": "2.6.3",
-				"mongodb": "~6.12.0",
+				"mongodb": "~6.13.0",
 				"mpath": "0.9.0",
 				"mquery": "5.0.0",
 				"ms": "2.1.3",
@@ -7287,52 +7309,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/mongoose"
-			}
-		},
-		"node_modules/mongoose/node_modules/mongodb": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
-			"integrity": "sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@mongodb-js/saslprep": "^1.1.9",
-				"bson": "^6.10.1",
-				"mongodb-connection-string-url": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.20.1"
-			},
-			"peerDependencies": {
-				"@aws-sdk/credential-providers": "^3.188.0",
-				"@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-				"gcp-metadata": "^5.2.0",
-				"kerberos": "^2.0.1",
-				"mongodb-client-encryption": ">=6.0.0 <7",
-				"snappy": "^7.2.2",
-				"socks": "^2.7.1"
-			},
-			"peerDependenciesMeta": {
-				"@aws-sdk/credential-providers": {
-					"optional": true
-				},
-				"@mongodb-js/zstd": {
-					"optional": true
-				},
-				"gcp-metadata": {
-					"optional": true
-				},
-				"kerberos": {
-					"optional": true
-				},
-				"mongodb-client-encryption": {
-					"optional": true
-				},
-				"snappy": {
-					"optional": true
-				},
-				"socks": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/mpath": {
@@ -7805,9 +7781,9 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.3",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-			"integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -8350,9 +8326,9 @@
 			}
 		},
 		"node_modules/possible-typed-array-names": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9951,9 +9927,9 @@
 			}
 		},
 		"node_modules/whatwg-url": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.0.tgz",
-			"integrity": "sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==",
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
+			"integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
 			"license": "MIT",
 			"dependencies": {
 				"tr46": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "3.7.5",
+	"version": "3.7.6-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -40,7 +40,7 @@
 		"@natlibfi/marc-record-serializers": "^10.1.5",
 		"@natlibfi/melinda-backend-commons": "^2.3.6",
 		"@natlibfi/melinda-commons": "^13.0.19",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.6",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^2.3.7",
 		"@natlibfi/melinda-record-match-validator": "^2.2.5",
 		"@natlibfi/melinda-record-matching": "^4.3.4",
 		"@natlibfi/melinda-rest-api-commons": "^4.2.4-alpha.5",
@@ -52,10 +52,10 @@
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.26.4",
-		"@babel/core": "^7.26.7",
+		"@babel/core": "^7.26.8",
 		"@babel/node": "^7.26.0",
-		"@babel/plugin-transform-runtime": "^7.25.9",
-		"@babel/preset-env": "^7.26.7",
+		"@babel/plugin-transform-runtime": "^7.26.8",
+		"@babel/preset-env": "^7.26.8",
 		"@babel/register": "^7.25.9",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
 		"@natlibfi/fixugen": "^2.0.12",


### PR DESCRIPTION
* Bump @natlibfi/melinda-marc-record-merge-reducers to 2.3.7 to handle non-all-cap f594 Ei vastaanotettu (MELKEHITYS-3155)

* Bump the development-dependencies group with 3 updates (#516)

Bumps the development-dependencies group with 3 updates: [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core), [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-runtime) and [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env).

* Bump @natlibfi/melinda-rest-api-commons (#515)


* Update deps

* 3.7.6-alpha.1