### PR TITLE
Feature handleMatchFailuresAsNew [MRA-841] & Dependency Updates (#286…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ While service is in operation:
 | VALIDATOR_MATCH_PACKAGES | No    | Defaults to `IDS,STANDARD_IDS,CONTENT`. |
 | STOP_WHEN_FOUND      | No        | A numeric presentation of boolean option to stop iterating matchers when a match is found. Defaults to `true`.  |
 | ACCEPT_ZERO_WITH_MAX_CANDIDATES | No | A numeric presentation of boolean option to accept zero matches result without erroring when matchStatus is false and stopReason is maxCandidates. Defaults to `false`. |
+| MATCH_FAILURES_AS_NEW | No | A numeric presentation of boolean option to handle a matching result where all matches fail matchValidation as a no-match matching result. This setting can be overridden by a job's operationSettings.matchFailuresAsNew. Defaults to `false`. |
 | LOG_NO_MATCHES | No | A numeric presentation of boolean option to keep MATCH_LOG logItems also when record did not find any matches. Defaults to `false`. |
 | LOG_INPUT_RECORD | No | A numeric presentation of boolean option to log incoming record in INPUT_RECORD_LOG logItem. Defaults to `false`. Note: logItems are not kept for records that end up with any of SKIPPED -recordStatuses.|
 | LOG_RESULT_RECORD | No | A numeric presentation of boolean option to log result record (that is/would be saved to database) in RESULT_RECORD_LOG logItem. Defaults to `false`. Note: logItems are not kept for records that end up with any of SKIPPED -recordStatuses. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "3.7.7",
+	"version": "3.8.0-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "3.7.7",
+			"version": "3.8.0-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.26.9",
@@ -3246,9 +3246,9 @@
 			}
 		},
 		"node_modules/bson": {
-			"version": "6.10.2",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.2.tgz",
-			"integrity": "sha512-5afhLTjqDSA3akH56E+/2J6kTDuSIlBxyXPdQslj9hcIgOUE378xdOfZvC/9q3LifJNI6KR/juZ+d0NRNYBwXg==",
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+			"integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.20.1"
@@ -3368,9 +3368,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001700",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
-			"integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
+			"version": "1.0.30001701",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
+			"integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
 			"dev": true,
 			"funding": [
 				{
@@ -4006,9 +4006,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.102",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
-			"integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
+			"version": "1.5.105",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.105.tgz",
+			"integrity": "sha512-ccp7LocdXx3yBhwiG0qTQ7XFrK48Ua2pxIxBdJO8cbddp/MvbBtPFzvnTchtyHQTsgqqczO8cdmAIbpMa0u2+g==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -4923,9 +4923,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fastq": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-			"integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -5068,13 +5068,13 @@
 			}
 		},
 		"node_modules/foreground-child": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"cross-spawn": "^7.0.0",
+				"cross-spawn": "^7.0.6",
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
@@ -5226,17 +5226,17 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-			"integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
+				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
+				"es-object-atoms": "^1.1.1",
 				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.0",
+				"get-proto": "^1.0.1",
 				"gopd": "^1.2.0",
 				"has-symbols": "^1.1.0",
 				"hasown": "^2.0.2",
@@ -7226,20 +7226,20 @@
 			"license": "MIT"
 		},
 		"node_modules/mongodb": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.0.tgz",
-			"integrity": "sha512-KeESYR5TEaFxOuwRqkOm3XOsMqCSkdeDMjaW5u2nuKfX7rqaofp7JQGoi7sVqQcNJTKuveNbzZtWMstb8ABP6Q==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.1.tgz",
+			"integrity": "sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.1.9",
-				"bson": "^6.10.1",
+				"bson": "^6.10.3",
 				"mongodb-connection-string-url": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=16.20.1"
 			},
 			"peerDependencies": {
-				"@aws-sdk/credential-providers": "^3.188.0",
+				"@aws-sdk/credential-providers": "^3.632.0",
 				"@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
 				"gcp-metadata": "^5.2.0",
 				"kerberos": "^2.0.1",
@@ -7282,9 +7282,9 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "8.10.1",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.10.1.tgz",
-			"integrity": "sha512-5beTeBZnJNndRXU9rxPol0JmTWZMAtgkPbooROkGilswvrZALDERY4cJrGZmgGwDS9dl0mxiB7si+Mv9Yms2fg==",
+			"version": "8.10.2",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.10.2.tgz",
+			"integrity": "sha512-DvqfK1s/JLwP39ogXULC8ygNDdmDber5ZbxZzELYtkzl9VGJ3K5T2MCLdpTs9I9J6DnkDyIHJwt7IOyMxh/Adw==",
 			"license": "MIT",
 			"dependencies": {
 				"bson": "^6.10.1",
@@ -8711,9 +8711,9 @@
 			}
 		},
 		"node_modules/reusify": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9872,9 +9872,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "11.0.5",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-			"integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -10189,12 +10189,12 @@
 			}
 		},
 		"node_modules/xregexp": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.1.tgz",
-			"integrity": "sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.2.tgz",
+			"integrity": "sha512-6hGgEMCGhqCTFEJbqmWrNIPqfpdirdGWkqshu7fFZddmTSfgv5Sn9D2SaKloR79s5VUiUlpwzg3CM3G6D3VIlw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime-corejs3": "^7.16.5"
+				"@babel/runtime-corejs3": "^7.26.9"
 			}
 		},
 		"node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "3.7.7",
+	"version": "3.8.0-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/src/config.js
+++ b/src/config.js
@@ -35,6 +35,8 @@ const logNoMatches = readEnvironmentVariable('LOG_NO_MATCHES', {defaultValue: 0,
 const logInputRecord = readEnvironmentVariable('LOG_INPUT_RECORD', {defaultValue: 0, format: v => parseBoolean(v)});
 const logResultRecord = readEnvironmentVariable('LOG_RESULT_RECORD', {defaultValue: 0, format: v => parseBoolean(v)});
 
+// Note: matchFailuresAsNew from operationSettings of the job overrides this default setting given in environmental variables
+const matchFailuresAsNew = readEnvironmentVariable('MATCH_FAILURES_AS_NEW', {defaultValue: false, format: v => parseBoolean(v)});
 
 // We could have also settings matchValidation and merge here
 
@@ -47,6 +49,7 @@ export const validatorOptions = {
   matchOptionsList: generateMatchOptionsList(),
   stopWhenFound,
   acceptZeroWithMaxCandidates,
+  matchFailuresAsNew,
   logOptions: {logNoMatches, logInputRecord, logResultRecord}
 };
 

--- a/src/interfaces/validator/index.js
+++ b/src/interfaces/validator/index.js
@@ -202,6 +202,7 @@ export default async function ({validatorOptions, mongoLogOperator}) {
   function checkAndUpdateId({record, headers}) {
     logger.debug(`--- Check and update id ---`);
     const recordF001 = getIdFromRecord(record);
+    //logger.debug(`Headers: ${JSON.stringify(headers)}`);
     const sequence = headers.recordMetadata.blobSequence;
     const {noStream, prio} = headers.operationSettings;
     logger.debug(`Operation: ${headers.operation}, Id from headers: <${headers.id}>, Id from record: <${recordF001}>, blobSequence: <${sequence}>, noStream: ${noStream}, prio: ${prio}`);


### PR DESCRIPTION
…) (#524)

* Add matchFailuresAsNew optional feature [MRA-841]
* NOTE: requires http ^3.5.0 to be usable

* Dependency update (#284)

* Bump the development-dependencies group with 4 updates (#283)

Updates `@babel/core` from 7.23.0 to 7.23.2
Updates `@babel/preset-env` from 7.22.20 to 7.23.2 Updates `@natlibfi/fixugen-http-server` from 1.1.6 to 1.1.7 Updates `eslint` from 8.50.0 to 8.51.0

* Bump the production-dependencies group with 5 updates (#282)

Bumps the production-dependencies group with 5 updates:

| Package | From | To |
| --- | --- | --- |
| [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime) | `7.23.1` | `7.23.2` | | [@natlibfi/marc-record-validate](https://github.com/natlibfi/marc-record-validate) | `8.0.1` | `8.0.3` | | [@natlibfi/melinda-commons](https://github.com/natlibfi/melinda-commons-js) | `13.0.6` | `13.0.7` | | [@natlibfi/melinda-marc-record-merge-reducers](https://github.com/natlibfi/melinda-marc-record-merge-reducers-js) | `2.0.17` | `2.0.18` | | [http-status](https://github.com/adaltas/node-http-status) | `1.7.0` | `1.7.3` |

* Update deps

* 3.8.0-alpha.1