### PR TITLE
Merge updates ; Dependency update (#620)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "4.0.3",
+	"version": "4.0.4-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "4.0.3",
+			"version": "4.0.4-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.1",
@@ -14,10 +14,10 @@
 				"@natlibfi/marc-record-serializers": "^11.0.1",
 				"@natlibfi/melinda-backend-commons": "^3.0.4",
 				"@natlibfi/melinda-commons": "^14.0.2",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^3.1.4",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^3.1.5",
 				"@natlibfi/melinda-record-match-validator": "^3.2.2",
 				"@natlibfi/melinda-record-matching": "^5.0.4",
-				"@natlibfi/melinda-rest-api-commons": "^5.0.5",
+				"@natlibfi/melinda-rest-api-commons": "^5.0.6",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3",
 				"deep-eql": "^5.0.2",
@@ -36,9 +36,9 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-			"integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+			"integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
 			"license": "MIT",
 			"dependencies": {
 				"core-js-pure": "^3.48.0"
@@ -787,9 +787,9 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.10.tgz",
-			"integrity": "sha512-0faUJY5xSUPIBwsEdN4F+0jYLbYjcFwCoQwLBDAYfpyTUaW52KojeB7RufDrjYcFXtqZgaDouCCO4w2xBdd+eA==",
+			"version": "12.0.11",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.11.tgz",
+			"integrity": "sha512-DrdlWIFVWJL4vVv4wgLs/Vx5Uvhpmpdh2wylqeOg/L8fAg0sOIPN05QChOXNyvb5PuGTJxV+ZxiF6Bw6VCJMMw==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/iso9-1995": "^1.1.1",
@@ -800,11 +800,10 @@
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/sfs-4900": "^2.0.0",
 				"@natlibfi/sru-client": "^7.0.1",
-				"cld3-asm": "^4.0.0",
 				"clone": "^2.1.2",
 				"debug": "^4.4.3",
+				"franc": "^6.2.0",
 				"isbn3": "^2.0.6",
-				"langs": "^2.0.0",
 				"xml2js": "^0.6.2",
 				"xregexp": "^5.1.2"
 			},
@@ -855,15 +854,14 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-3.1.4.tgz",
-			"integrity": "sha512-N/IWvIjSuZn4xl6Qj684604lTO6USG3hoXzKVcc0vN95jTs9tElUDbIU5hkJGKP77P+my7qJvv2qTGJOfn4vhQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-3.1.5.tgz",
+			"integrity": "sha512-ql+UuHl5Mn83nsLgK00j2ikg5R1ARM6khOsGON7Z9BMuN7nxQONr3RHUq/wlhpLLAT5uA0s2zx5r5/C4Vfw/3Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.1",
 				"@natlibfi/marc-record-merge": "^8.0.1",
-				"@natlibfi/marc-record-validate": "^9.0.0",
-				"@natlibfi/marc-record-validators-melinda": "^12.0.10",
+				"@natlibfi/marc-record-validators-melinda": "^12.0.11",
 				"clone": "^2.1.2",
 				"debug": "^4.4.3",
 				"isbn3": "^2.0.6"
@@ -939,15 +937,15 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-5.0.5.tgz",
-			"integrity": "sha512-q7/DWX0fNq7dMKxHEQiU2KMl3x4gR1kOn+kM+bhaoR1ZeMGwzIRsj8LOpjLpL2AJNjP7xL14uTGXeQoK887JCg==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-5.0.6.tgz",
+			"integrity": "sha512-9zDZxIrmKIYXXmPGha2cGQ7h1gh6YDi5YGglG02McdsdZL2/LKi7OekS5b0WHDzRZcPo0M0gy67kWoyV6ZJYIA==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.1",
 				"@natlibfi/marc-record-serializers": "^11.0.1",
 				"@natlibfi/marc-record-validate": "^9.0.0",
-				"@natlibfi/marc-record-validators-melinda": "^12.0.6",
+				"@natlibfi/marc-record-validators-melinda": "^12.0.10",
 				"@natlibfi/melinda-backend-commons": "^3.0.4",
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"amqplib": "^0.10.9",
@@ -1315,18 +1313,6 @@
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/cld3-asm": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cld3-asm/-/cld3-asm-4.0.0.tgz",
-			"integrity": "sha512-eQq2detA7A54X9NSeunvHf4KcWlZKE/i98+V6NjWNDqF28GGk8Qk9XWApSywBjEcmPKR48zkabFWBoa1ExM/AQ==",
-			"license": "MIT",
-			"dependencies": {
-				"emscripten-wasm-loader": "^3.0.3"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/cliui": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -1357,6 +1343,16 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/collapse-white-space": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+			"integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/color": {
@@ -1430,9 +1426,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-			"integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+			"integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -1593,20 +1589,6 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
 			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
 			"license": "MIT"
-		},
-		"node_modules/emscripten-wasm-loader": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/emscripten-wasm-loader/-/emscripten-wasm-loader-3.0.3.tgz",
-			"integrity": "sha512-fyq2maBt5LOou27LEBlL5H6G04BxgSamXkvmMsAuIT6rd8ioH4BxNQhuyl6jVPeODh6U8Wk1BoFZxzHpg3o8wA==",
-			"license": "MIT",
-			"dependencies": {
-				"getroot": "^1.0.0",
-				"nanoid": "^2.0.3",
-				"unixify": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/enabled": {
 			"version": "2.0.0",
@@ -1930,9 +1912,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-			"integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -1941,6 +1923,19 @@
 			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
 			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
 			"license": "MIT"
+		},
+		"node_modules/franc": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/franc/-/franc-6.2.0.tgz",
+			"integrity": "sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==",
+			"license": "MIT",
+			"dependencies": {
+				"trigram-utils": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -1961,19 +1956,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/getroot": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/getroot/-/getroot-1.0.0.tgz",
-			"integrity": "sha512-W9Q31kOv921dQuZBeAbK4R/dAPbC0WkhZD3alLcdVwjSkEtS1aX8twrzG3I5yo0sQ88M/d4JOqVbRiCuI/XPNA==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^1.7.1"
-			},
-			"engines": {
-				"node": ">=4.2.4",
-				"npm": ">=3.0.0"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -2179,12 +2161,6 @@
 			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
 			"license": "MIT"
 		},
-		"node_modules/langs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/langs/-/langs-2.0.0.tgz",
-			"integrity": "sha512-v4pxOBEQVN1WBTfB1crhTtxzNLZU9HPWgadlwzWKISJtt6Ku/CnpBrwVy+jFv8StjxsPfwPFzO0CMwdZLJ0/BA==",
-			"license": "MIT"
-		},
 		"node_modules/leac": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
@@ -2350,9 +2326,9 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.3.0.tgz",
-			"integrity": "sha512-Tv2p3DLBkftoGFp+VM/19k0t0RYPAAYjGIbCVGlV6Tf5Dnq6TICfYyeKeYvwQ06nK9sRDvymP3B+tjGHnUlaxw==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.3.1.tgz",
+			"integrity": "sha512-58DuQti+LlRS74/UfWN4F3wZsC0Yr1dgTWZ2Wd3/TuSvm6rIdyAjDWbx2xGyuBooqJYdAWotVv4mQgVdivh+3Q==",
 			"license": "MIT",
 			"dependencies": {
 				"kareem": "3.2.0",
@@ -2471,22 +2447,14 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
-		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
+		"node_modules/n-gram": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+			"integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
 			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/natural": {
@@ -2542,24 +2510,6 @@
 			"engines": {
 				"node": ">= 10.18.1",
 				"npm": ">= 6.13.4"
-			}
-		},
-		"node_modules/normalize-diacritics/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
-		},
-		"node_modules/normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-			"license": "MIT",
-			"dependencies": {
-				"remove-trailing-separator": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/one-time": {
@@ -2846,12 +2796,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
-			"license": "ISC"
-		},
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -2888,9 +2832,9 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-			"integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -3067,6 +3011,20 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/trigram-utils": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
+			"integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"collapse-white-space": "^2.0.0",
+				"n-gram": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/triple-beam": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -3077,9 +3035,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
 		},
 		"node_modules/type-check": {
@@ -3100,18 +3058,6 @@
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
 			"integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
 			"license": "MIT"
-		},
-		"node_modules/unixify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
-			"integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
-			"license": "MIT",
-			"dependencies": {
-				"normalize-path": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "4.0.3",
+	"version": "4.0.4-alpha.1",
 	"type": "module",
 	"main": "./dist/index.js",
 	"engines": {
@@ -38,10 +38,10 @@
 		"@natlibfi/marc-record-serializers": "^11.0.1",
 		"@natlibfi/melinda-backend-commons": "^3.0.4",
 		"@natlibfi/melinda-commons": "^14.0.2",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^3.1.4",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^3.1.5",
 		"@natlibfi/melinda-record-match-validator": "^3.2.2",
 		"@natlibfi/melinda-record-matching": "^5.0.4",
-		"@natlibfi/melinda-rest-api-commons": "^5.0.5",
+		"@natlibfi/melinda-rest-api-commons": "^5.0.6",
 		"@natlibfi/sru-client": "^7.0.1",
 		"debug": "^4.4.3",
 		"deep-eql": "^5.0.2",


### PR DESCRIPTION
* Merge updates, including: 
fixes for merging f041
fixes for merging f341
fixes for handling $7
fixes for handling $8
allow merging records with LDR/07 'a' vs 'b'

* Bump the production-dependencies group across 1 directory with 2 updates (#619) 
Updates `@natlibfi/melinda-marc-record-merge-reducers` from 3.1.4 to 3.1.5 
Updates `@natlibfi/melinda-rest-api-commons` from 5.0.5 to 5.0.6

* Update deps

* 4.0.4-alpha.1