### PR TITLE
Matching updates & Node 24 & Dependency update (#652)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -11,14 +11,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x, 26.x]
+        node-version: [24.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -35,7 +35,7 @@ jobs:
     container: node:24
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: mikaelvesavuori/license-compliance-action@v1
         with:
           exclude_pattern: /^@natlibfi/
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: nodejsscan scan
       id: njsscan
       uses: ajinabraham/njsscan-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine as builder
+FROM node:24-alpine as builder
 WORKDIR /home/node
 
 COPY --chown=node:node . build
@@ -8,7 +8,7 @@ RUN apk add -U --no-cache --virtual .build-deps git sudo \
   && sudo -u node sh -c 'cp -r build/dist/* build/package.json build/package-lock.json .' \
   && sudo -u node sh -c 'npm ci --ignore-scripts --production'
 
-FROM node:22-alpine
+FROM node:24-alpine
 CMD ["/usr/local/bin/node", "index.js"]
 WORKDIR /home/node
 USER node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "4.2.0",
+	"version": "5.0.0-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "4.2.0",
+			"version": "5.0.0-alpha.2",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
 				"@natlibfi/marc-record-merge": "^8.0.1",
 				"@natlibfi/marc-record-serializers": "^11.0.3",
-				"@natlibfi/melinda-backend-commons": "^3.0.5",
+				"@natlibfi/melinda-backend-commons": "^3.0.6",
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/melinda-marc-record-merge-reducers": "^3.2.2",
-				"@natlibfi/melinda-record-match-validator": "^3.2.4",
-				"@natlibfi/melinda-record-matching": "^5.1.3",
+				"@natlibfi/melinda-record-match-validator": "^3.2.5",
+				"@natlibfi/melinda-record-matching": "^5.1.6",
 				"@natlibfi/melinda-rest-api-commons": "^5.0.7",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3",
@@ -29,7 +29,7 @@
 				"@natlibfi/fixura": "^4.0.1",
 				"cross-env": "^10.1.0",
 				"esbuild": "^0.28.1",
-				"eslint": "^10.5.0"
+				"eslint": "^10.7.0"
 			},
 			"engines": {
 				"node": ">=22"
@@ -829,17 +829,17 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.5.tgz",
-			"integrity": "sha512-dS79RyDqPwXIDsTO+9TWfhOu1/R9F/54QJTi4W6ZQCPOOOp5iy4/WUjj7yduqhL1pIPhxdYzDYDv6Jv596JRLw==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.6.tgz",
+			"integrity": "sha512-HDieSmekhG4k628HfybCkPR07rqjRqPd9NT/TMZ2U5xlHfkCGvMTBGcfFLZxxe09y0lBsHbhrO9yvt6GkmXyEQ==",
 			"license": "MIT",
 			"dependencies": {
 				"base64-url": "^2.3.3",
 				"debug": "^4.4.3",
 				"express-winston": "^4.2.0",
-				"html-to-text": "^9.0.5",
+				"html-to-text": "^10.0.0",
 				"moment": "^2.30.1",
-				"nodemailer": "^8.0.4",
+				"nodemailer": "^9.0.1",
 				"winston": "^3.19.0",
 				"yargs": "^18.0.0"
 			},
@@ -849,7 +849,7 @@
 				"mailer": "dist/mailerCli.js"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": ">=24"
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
@@ -886,14 +886,14 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-match-validator": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-match-validator/-/melinda-record-match-validator-3.2.4.tgz",
-			"integrity": "sha512-qrhi7hbyUyolPMdhlcJYcywlu7N6ADlzzYWR5LZKqKCRMWC3GEl4kqltVQMTAUpgz5xxxP6aIXU6Bah5dv8psw==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-match-validator/-/melinda-record-match-validator-3.2.5.tgz",
+			"integrity": "sha512-RWfoygGK3yaRc4oaXFOvSOUffcofyvr/lzy+IFexjAPNgvIE9hSHv8BTE8544s1GfCWEvYyJ3HaLeQJLJHZNnQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
 				"@natlibfi/melinda-commons": "^14.0.2",
-				"@natlibfi/melinda-record-matching": "^5.1.3",
+				"@natlibfi/melinda-record-matching": "^5.1.4",
 				"debug": "^4.4.3",
 				"isbn3": "^2.0.8",
 				"moment": "^2.30.1"
@@ -903,28 +903,25 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-matching": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-5.1.3.tgz",
-			"integrity": "sha512-35uZK7Z3N+eogpwlEFeXALuHUxJR5xirPORxb3V9s/cXm0Y9gOKwfTeCv5SxnwRJvpisNSJzgG8KQWeOkzULEA==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-5.1.6.tgz",
+			"integrity": "sha512-fJgyQa/pAWuFlDoCwRcD6tvNt/9X0qJshxofLzc1y3LNo0DxwJ3RFZQrU88EBWXErTGgbCSGph9cxasfvrnDlw==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
-				"@natlibfi/marc-record-serializers": "^11.0.3",
 				"@natlibfi/marc-record-validators-melinda": "^12.0.15",
 				"@natlibfi/melinda-commons": "^14.0.2",
-				"@natlibfi/sru-client": "^7.0.1",
+				"@natlibfi/sru-client": "^7.0.2",
 				"debug": "^4.4.3",
-				"isbn3": "^2.0.8",
-				"moment": "^2.30.1",
+				"isbn3": "^2.0.9",
 				"natural": "^8.1.1",
-				"uuid": "^14.0.0",
 				"yargs": "^18.0.0"
 			},
 			"bin": {
 				"melinda-record-matching": "dist/cli.js"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": ">=24"
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
@@ -960,21 +957,21 @@
 			}
 		},
 		"node_modules/@natlibfi/sru-client": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-7.0.1.tgz",
-			"integrity": "sha512-L/lYCxUe6hFlvmqEunnipHa3tEb9qxVARCsB/U0bBNzTakYU6OCKE6Vv/p/N+H2Y0tUa3yLPpwkal8sLCSywnA==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-7.0.2.tgz",
+			"integrity": "sha512-rhx55CwK+wHjbMVtD9DLVQUsLSq2mu9qwiWrRtC5SRICax+b13NGgIUm52yXMFfFhNLorDI5WPWwlxwFOq97Hg==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.1",
-				"@natlibfi/marc-record-serializers": "^11.0.1",
-				"@natlibfi/melinda-backend-commons": "^3.0.2",
+				"@natlibfi/marc-record": "^10.0.2",
+				"@natlibfi/marc-record-serializers": "^11.0.3",
+				"@natlibfi/melinda-backend-commons": "^3.0.6",
 				"debug": "^4.4.3",
 				"http-status": "^2.1.0",
 				"xml2js": "^0.6.2",
 				"yargs": "^18.0.0"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": ">=24"
 			}
 		},
 		"node_modules/@redis/bloom": {
@@ -1050,16 +1047,19 @@
 			}
 		},
 		"node_modules/@selderee/plugin-htmlparser2": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
-			"integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.12.0.tgz",
+			"integrity": "sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==",
 			"license": "MIT",
 			"dependencies": {
-				"domhandler": "^5.0.3",
-				"selderee": "^0.11.0"
+				"domelementtype": "~2.3.0",
+				"domhandler": "~5.0.3"
 			},
 			"funding": {
-				"url": "https://ko-fi.com/killymxi"
+				"url": "https://github.com/sponsors/KillyMXI"
+			},
+			"peerDependencies": {
+				"selderee": "~0.12.0"
 			}
 		},
 		"node_modules/@so-ric/colorspace": {
@@ -1503,13 +1503,13 @@
 			"integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==",
 			"license": "MIT"
 		},
-		"node_modules/deepmerge": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"license": "MIT",
+		"node_modules/deepmerge-ts": {
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+			"integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+			"license": "BSD-3-Clause",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/dom-serializer": {
@@ -1668,9 +1668,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-			"integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+			"integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -1979,25 +1979,28 @@
 			}
 		},
 		"node_modules/html-to-text": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
-			"integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.0.tgz",
+			"integrity": "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@selderee/plugin-htmlparser2": "^0.11.0",
-				"deepmerge": "^4.3.1",
+				"@selderee/plugin-htmlparser2": "~0.12.0",
+				"deepmerge-ts": "^7.1.5",
 				"dom-serializer": "^2.0.0",
-				"htmlparser2": "^8.0.2",
-				"selderee": "^0.11.0"
+				"htmlparser2": "^10.1.0",
+				"selderee": "~0.12.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/KillyMXI"
 			}
 		},
 		"node_modules/htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+			"integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
 			"funding": [
 				"https://github.com/fb55/htmlparser2?sponsor=1",
 				{
@@ -2009,8 +2012,20 @@
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
+				"domutils": "^3.2.2",
+				"entities": "^7.0.1"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/http-status": {
@@ -2084,9 +2099,9 @@
 			}
 		},
 		"node_modules/isbn3": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.8.tgz",
-			"integrity": "sha512-wDzOEM2Tox7nIOCqH7yHIhQs+bltttaGqMTk7J72VIhI9w6nLsFnHMrUtidQJR/WvZfg+qXeF2A9WFfs2nxYCg==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.9.tgz",
+			"integrity": "sha512-4kajHJekOl7xCeEyoMqs6lczR5RKJp78le3pomz0Gi1pCj3GBrSZvlftTFQmr5hcdjQskm/y4LsWITZWweo6XQ==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",
@@ -2160,12 +2175,12 @@
 			"license": "MIT"
 		},
 		"node_modules/leac": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
-			"integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/leac/-/leac-0.7.0.tgz",
+			"integrity": "sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==",
 			"license": "MIT",
 			"funding": {
-				"url": "https://ko-fi.com/killymxi"
+				"url": "https://github.com/sponsors/KillyMXI"
 			}
 		},
 		"node_modules/levn": {
@@ -2501,9 +2516,9 @@
 			}
 		},
 		"node_modules/nodemailer": {
-			"version": "8.0.9",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.9.tgz",
-			"integrity": "sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+			"integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
@@ -2583,16 +2598,16 @@
 			}
 		},
 		"node_modules/parseley": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
-			"integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/parseley/-/parseley-0.13.1.tgz",
+			"integrity": "sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A==",
 			"license": "MIT",
 			"dependencies": {
-				"leac": "^0.6.0",
-				"peberminta": "^0.9.0"
+				"leac": "^0.7.0",
+				"peberminta": "^0.10.0"
 			},
 			"funding": {
-				"url": "https://ko-fi.com/killymxi"
+				"url": "https://github.com/sponsors/KillyMXI"
 			}
 		},
 		"node_modules/path-exists": {
@@ -2616,12 +2631,12 @@
 			}
 		},
 		"node_modules/peberminta": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
-			"integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.10.0.tgz",
+			"integrity": "sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==",
 			"license": "MIT",
 			"funding": {
-				"url": "https://ko-fi.com/killymxi"
+				"url": "https://github.com/sponsors/KillyMXI"
 			}
 		},
 		"node_modules/pg": {
@@ -2852,15 +2867,15 @@
 			}
 		},
 		"node_modules/selderee": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
-			"integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/selderee/-/selderee-0.12.0.tgz",
+			"integrity": "sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==",
 			"license": "MIT",
 			"dependencies": {
-				"parseley": "^0.12.0"
+				"parseley": "~0.13.1"
 			},
 			"funding": {
-				"url": "https://ko-fi.com/killymxi"
+				"url": "https://github.com/sponsors/KillyMXI"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -3095,19 +3110,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
-		},
-		"node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
 		},
 		"node_modules/webidl-conversions": {
 			"version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0",
 				"@natlibfi/melinda-record-match-validator": "^3.2.5",
-				"@natlibfi/melinda-record-matching": "^5.1.7-alpha.1",
+				"@natlibfi/melinda-record-matching": "^6.0.0",
 				"@natlibfi/melinda-rest-api-commons": "^5.0.7",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3",
@@ -950,13 +950,13 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-matching": {
-			"version": "5.1.7-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-5.1.7-alpha.1.tgz",
-			"integrity": "sha512-GfARTJ3dga5hRfPhTjrBkt+kY1QPZ5+HjH6zKSxLPsyXWDvPD/4wkzfthahcLydmdetgoIfVfoSb2oY7gtMfkA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-6.0.0.tgz",
+			"integrity": "sha512-xHJg93OZ9F/CdoC3lKp4BwW1gWzK5tk28JZRpn9Z3cApuI1yooB1izZovT00cQ71xz4UcikvWrvF9URf7ej8fg==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
-				"@natlibfi/marc-record-validators-melinda": "^12.0.15",
+				"@natlibfi/marc-record-validators-melinda": "^13.0.0",
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/sru-client": "^7.0.2",
 				"debug": "^4.4.3",
@@ -966,6 +966,31 @@
 			},
 			"bin": {
 				"melinda-record-matching": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=24"
+			}
+		},
+		"node_modules/@natlibfi/melinda-record-matching/node_modules/@natlibfi/marc-record-validators-melinda": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-13.0.0.tgz",
+			"integrity": "sha512-M6G6TdERFfhr9rP9wvKhmcgGSyzk+Wlsh7V+GEIft+DnX83oBKNztmSpWX7htocFjPk+HiutRuY7oJUrXxtDvg==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/iso9-1995": "^1.1.4",
+				"@natlibfi/issn-verify": "^2.0.3",
+				"@natlibfi/marc-record": "^10.0.2",
+				"@natlibfi/marc-record-serializers": "^11.0.3",
+				"@natlibfi/marc-record-validate": "^9.0.1",
+				"@natlibfi/melinda-commons": "^14.0.2",
+				"@natlibfi/sfs-4900": "^2.0.0",
+				"@natlibfi/sru-client": "^7.0.2",
+				"clone": "^2.1.2",
+				"debug": "^4.4.3",
+				"franc": "^6.2.0",
+				"isbn3": "^2.0.9",
+				"xml2js": "^0.6.2",
+				"xregexp": "^5.1.2"
 			},
 			"engines": {
 				"node": ">=24"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "5.0.0-alpha.2",
+	"version": "5.0.0-alpha.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "5.0.0-alpha.2",
+			"version": "5.0.0-alpha.4",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
@@ -14,9 +14,9 @@
 				"@natlibfi/marc-record-serializers": "^11.0.3",
 				"@natlibfi/melinda-backend-commons": "^3.0.6",
 				"@natlibfi/melinda-commons": "^14.0.2",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^3.2.2",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0-alpha.1",
 				"@natlibfi/melinda-record-match-validator": "^3.2.5",
-				"@natlibfi/melinda-record-matching": "^5.1.6",
+				"@natlibfi/melinda-record-matching": "^5.1.7-alpha.1",
 				"@natlibfi/melinda-rest-api-commons": "^5.0.7",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3",
@@ -32,7 +32,7 @@
 				"eslint": "^10.7.0"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": ">=24"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
@@ -722,9 +722,9 @@
 			}
 		},
 		"node_modules/@natlibfi/iso9-1995": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/iso9-1995/-/iso9-1995-1.1.3.tgz",
-			"integrity": "sha512-6XEHImnzbNPRzQG1q97IFXD5gRHTkfmvCg2yAhWX+zqHllJxlwA7D9SXD1eYfe7nzRc6yQTIpqmzc2MQQyYhiw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/iso9-1995/-/iso9-1995-1.1.4.tgz",
+			"integrity": "sha512-i5NAxdIqux52J3IFHzghM3J0oO2gXROp3C3FYsQkNE/8kiSDer2RIl4ga/7Cu3OV6tKeniDS+MldrhqKh6edXQ==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.3"
@@ -868,21 +868,46 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-3.2.2.tgz",
-			"integrity": "sha512-YilMYH5gHQLWHjCy65kzpDPppfajslqm4qCOx5azukww+FuK/n1EXW4uhhUwFpB72lRawCk34vhyYZKz8N2MkA==",
+			"version": "4.0.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-4.0.0-alpha.1.tgz",
+			"integrity": "sha512-aq7W1JmDlzAyR1sJWSeYGcf1Gjy9Bi/4otDd7aLpkbEo2DE7gbRRio+mvoOHzTLTIAYyycpHrPUnlEjhIfHo9A==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
 				"@natlibfi/marc-record-merge": "^8.0.1",
 				"@natlibfi/marc-record-validate": "^9.0.1",
-				"@natlibfi/marc-record-validators-melinda": "^12.0.15",
+				"@natlibfi/marc-record-validators-melinda": "^13.0.0-alpha.1",
 				"clone": "^2.1.2",
 				"debug": "^4.4.3",
 				"isbn3": "^2.0.8"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": ">=24"
+			}
+		},
+		"node_modules/@natlibfi/melinda-marc-record-merge-reducers/node_modules/@natlibfi/marc-record-validators-melinda": {
+			"version": "13.0.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-13.0.0-alpha.1.tgz",
+			"integrity": "sha512-Khj1NkgPYaATxnSFuflweACLaiKTRSxSVGdkCMWUKadU1v9q6aibMsZrGHIbGy08l8Gjs0z4n0iHzqIOqKSayw==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/iso9-1995": "^1.1.4",
+				"@natlibfi/issn-verify": "^2.0.3",
+				"@natlibfi/marc-record": "^10.0.2",
+				"@natlibfi/marc-record-serializers": "^11.0.3",
+				"@natlibfi/marc-record-validate": "^9.0.1",
+				"@natlibfi/melinda-commons": "^14.0.2",
+				"@natlibfi/sfs-4900": "^2.0.0",
+				"@natlibfi/sru-client": "^7.0.2",
+				"clone": "^2.1.2",
+				"debug": "^4.4.3",
+				"franc": "^6.2.0",
+				"isbn3": "^2.0.9",
+				"xml2js": "^0.6.2",
+				"xregexp": "^5.1.2"
+			},
+			"engines": {
+				"node": ">=24"
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-match-validator": {
@@ -902,10 +927,32 @@
 				"node": ">=22"
 			}
 		},
-		"node_modules/@natlibfi/melinda-record-matching": {
+		"node_modules/@natlibfi/melinda-record-match-validator/node_modules/@natlibfi/melinda-record-matching": {
 			"version": "5.1.6",
 			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-5.1.6.tgz",
 			"integrity": "sha512-fJgyQa/pAWuFlDoCwRcD6tvNt/9X0qJshxofLzc1y3LNo0DxwJ3RFZQrU88EBWXErTGgbCSGph9cxasfvrnDlw==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^10.0.2",
+				"@natlibfi/marc-record-validators-melinda": "^12.0.15",
+				"@natlibfi/melinda-commons": "^14.0.2",
+				"@natlibfi/sru-client": "^7.0.2",
+				"debug": "^4.4.3",
+				"isbn3": "^2.0.9",
+				"natural": "^8.1.1",
+				"yargs": "^18.0.0"
+			},
+			"bin": {
+				"melinda-record-matching": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=24"
+			}
+		},
+		"node_modules/@natlibfi/melinda-record-matching": {
+			"version": "5.1.7-alpha.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-5.1.7-alpha.1.tgz",
+			"integrity": "sha512-GfARTJ3dga5hRfPhTjrBkt+kY1QPZ5+HjH6zKSxLPsyXWDvPD/4wkzfthahcLydmdetgoIfVfoSb2oY7gtMfkA==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1305,9 +1305,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@natlibfi/marc-record-serializers": "^11.0.3",
 				"@natlibfi/melinda-backend-commons": "^3.0.6",
 				"@natlibfi/melinda-commons": "^14.0.2",
-				"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0-alpha.1",
+				"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0",
 				"@natlibfi/melinda-record-match-validator": "^3.2.5",
 				"@natlibfi/melinda-record-matching": "^5.1.7-alpha.1",
 				"@natlibfi/melinda-rest-api-commons": "^5.0.7",
@@ -868,15 +868,15 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
-			"version": "4.0.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-4.0.0-alpha.1.tgz",
-			"integrity": "sha512-aq7W1JmDlzAyR1sJWSeYGcf1Gjy9Bi/4otDd7aLpkbEo2DE7gbRRio+mvoOHzTLTIAYyycpHrPUnlEjhIfHo9A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-marc-record-merge-reducers/-/melinda-marc-record-merge-reducers-4.0.0.tgz",
+			"integrity": "sha512-FkDBxCV+QUwu3K2Q2FhLBWm7mE0f4DaEINpiQSjQ81YASe1onq3/oqkJSp5Vv4bDvingU7toXvSOHrqn4WY95g==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
 				"@natlibfi/marc-record-merge": "^8.0.1",
 				"@natlibfi/marc-record-validate": "^9.0.1",
-				"@natlibfi/marc-record-validators-melinda": "^13.0.0-alpha.1",
+				"@natlibfi/marc-record-validators-melinda": "^13.0.0",
 				"clone": "^2.1.2",
 				"debug": "^4.4.3",
 				"isbn3": "^2.0.8"
@@ -886,9 +886,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers/node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "13.0.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-13.0.0-alpha.1.tgz",
-			"integrity": "sha512-Khj1NkgPYaATxnSFuflweACLaiKTRSxSVGdkCMWUKadU1v9q6aibMsZrGHIbGy08l8Gjs0z4n0iHzqIOqKSayw==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-13.0.0.tgz",
+			"integrity": "sha512-M6G6TdERFfhr9rP9wvKhmcgGSyzk+Wlsh7V+GEIft+DnX83oBKNztmSpWX7htocFjPk+HiutRuY7oJUrXxtDvg==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/iso9-1995": "^1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "5.0.0-alpha.4",
+	"version": "5.0.0-alpha.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "5.0.0-alpha.4",
+			"version": "5.0.0-alpha.5",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "5.0.0-alpha.2",
+	"version": "5.0.0-alpha.4",
 	"type": "module",
 	"main": "./dist/index.js",
 	"engines": {
@@ -38,9 +38,9 @@
 		"@natlibfi/marc-record-serializers": "^11.0.3",
 		"@natlibfi/melinda-backend-commons": "^3.0.6",
 		"@natlibfi/melinda-commons": "^14.0.2",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^3.2.2",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0-alpha.1",
 		"@natlibfi/melinda-record-match-validator": "^3.2.5",
-		"@natlibfi/melinda-record-matching": "^5.1.6",
+		"@natlibfi/melinda-record-matching": "^5.1.7-alpha.1",
 		"@natlibfi/melinda-rest-api-commons": "^5.0.7",
 		"@natlibfi/sru-client": "^7.0.1",
 		"debug": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "5.0.0-alpha.4",
+	"version": "5.0.0-alpha.5",
 	"type": "module",
 	"main": "./dist/index.js",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "4.2.0",
+	"version": "5.0.0-alpha.2",
 	"type": "module",
 	"main": "./dist/index.js",
 	"engines": {
-		"node": ">=22"
+		"node": ">=24"
 	},
 	"private": true,
 	"scripts": {
@@ -36,11 +36,11 @@
 		"@natlibfi/marc-record": "^10.0.2",
 		"@natlibfi/marc-record-merge": "^8.0.1",
 		"@natlibfi/marc-record-serializers": "^11.0.3",
-		"@natlibfi/melinda-backend-commons": "^3.0.5",
+		"@natlibfi/melinda-backend-commons": "^3.0.6",
 		"@natlibfi/melinda-commons": "^14.0.2",
 		"@natlibfi/melinda-marc-record-merge-reducers": "^3.2.2",
-		"@natlibfi/melinda-record-match-validator": "^3.2.4",
-		"@natlibfi/melinda-record-matching": "^5.1.3",
+		"@natlibfi/melinda-record-match-validator": "^3.2.5",
+		"@natlibfi/melinda-record-matching": "^5.1.6",
 		"@natlibfi/melinda-rest-api-commons": "^5.0.7",
 		"@natlibfi/sru-client": "^7.0.1",
 		"debug": "^4.4.3",
@@ -53,7 +53,7 @@
 		"@natlibfi/fixura": "^4.0.1",
 		"cross-env": "^10.1.0",
 		"esbuild": "^0.28.1",
-		"eslint": "^10.5.0"
+		"eslint": "^10.7.0"
 	},
 	"overrides": {
 		"nanoid": "^3.3.8"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@natlibfi/melinda-commons": "^14.0.2",
 		"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0",
 		"@natlibfi/melinda-record-match-validator": "^3.2.5",
-		"@natlibfi/melinda-record-matching": "^5.1.7-alpha.1",
+		"@natlibfi/melinda-record-matching": "^6.0.0",
 		"@natlibfi/melinda-rest-api-commons": "^5.0.7",
 		"@natlibfi/sru-client": "^7.0.1",
 		"debug": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@natlibfi/marc-record-serializers": "^11.0.3",
 		"@natlibfi/melinda-backend-commons": "^3.0.6",
 		"@natlibfi/melinda-commons": "^14.0.2",
-		"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0-alpha.1",
+		"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0",
 		"@natlibfi/melinda-record-match-validator": "^3.2.5",
 		"@natlibfi/melinda-record-matching": "^5.1.7-alpha.1",
 		"@natlibfi/melinda-rest-api-commons": "^5.0.7",


### PR DESCRIPTION
* Update https://github.com/NatLibFi/melinda-record-matching-js/releases/tag/v5.1.6 

> Support MELKEHITYS-3492: prefer FIKKA and non-ALL CAPS records (partial fix) *
> Support MELKEHITYS-3496 by implementing 245$a->245$a$n split in certain contexts
> Support MELKEHITYS-3485 (simplified): allow 245$a vs 245$b pairs (with lower positive score) **
> Support f015 and f028 in candidate searches (MELKEHITYS-3476) (not really tested, but just allowed them tags)
> note that this applies only to a set of records that are fetched by a single SRU query. Eg. if we fetch records 1...10 of 44 records) these are sorted so that FIKKA comes first, non-all caps second and ALL CAPS last. So this should work on small sets, but be iffier with larger sets
> ** Simplified: f246 and f490 are not checked. If $b-less f245 $a pairs with other f245's $b, we ignore other record's $a (= assume it's a series name etc.)
> 
> Handle copyright years in bib/publication-time-allow-cons-years-multi
> * Do not mismatch if normal year from one record matches copyright year from another record
> 


* Bump actions/setup-node from 6 to 7 (#651) Bumps [actions/setup-node](https://github.com/actions/setup-node) from 6 to 7.

* Bump the production-dependencies group across 1 directory with 4 updates (#650) Updates `@natlibfi/melinda-backend-commons` from 3.0.5 to 3.0.6 Updates `@natlibfi/melinda-record-match-validator` from 3.2.4 to 3.2.5 Updates `@natlibfi/melinda-record-matching` from 5.1.3 to 5.1.4 Updates `@natlibfi/sru-client` from 7.0.1 to 7.0.2

* Bump eslint from 10.5.0 to 10.6.0 in the development-dependencies group (#649) Updates `eslint` from 10.5.0 to 10.6.0

* Bump actions/checkout from 6 to 7 (#647) Bumps [actions/checkout](https://github.com/actions/checkout) from 6 to 7.

* Update deps

* Update node version to 24

* 5.0.0-alpha.2