### PR TITLE
Match updates & Dependency update (#657)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
 	"name": "@natlibfi/melinda-rest-api-validator",
-	"version": "5.0.0",
+	"version": "5.0.1-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-validator",
-			"version": "5.0.0",
+			"version": "5.0.1-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
 				"@natlibfi/marc-record-merge": "^8.0.1",
 				"@natlibfi/marc-record-serializers": "^11.0.3",
 				"@natlibfi/melinda-backend-commons": "^3.0.6",
-				"@natlibfi/melinda-commons": "^14.0.2",
+				"@natlibfi/melinda-commons": "^15.0.1",
 				"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0",
 				"@natlibfi/melinda-record-match-validator": "^3.2.5",
-				"@natlibfi/melinda-record-matching": "^6.0.0",
-				"@natlibfi/melinda-rest-api-commons": "^5.0.7",
+				"@natlibfi/melinda-record-matching": "^6.0.2",
+				"@natlibfi/melinda-rest-api-commons": "^6.0.0",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3",
 				"deep-eql": "^5.0.2",
@@ -29,7 +29,7 @@
 				"@natlibfi/fixura": "^4.0.1",
 				"cross-env": "^10.1.0",
 				"esbuild": "^0.28.1",
-				"eslint": "^10.7.0"
+				"eslint": "^10.8.0"
 			},
 			"engines": {
 				"node": ">=24"
@@ -574,9 +574,9 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+			"integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -828,6 +828,21 @@
 				"@natlibfi/marc-record-validate": "^9.0.0"
 			}
 		},
+		"node_modules/@natlibfi/marc-record-validators-melinda/node_modules/@natlibfi/melinda-commons": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.2.tgz",
+			"integrity": "sha512-Q8Lx4A1I17Hya2vwlSOgfCRC63PFA3+3fjMQjgkyX3Wt1x4ATmbx18kJ9ecYtiZKqBTHm1qChrXsWAoVQ69Ewg==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/sru-client": "^7.0.1",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.6.tgz",
@@ -853,18 +868,18 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "14.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.2.tgz",
-			"integrity": "sha512-Q8Lx4A1I17Hya2vwlSOgfCRC63PFA3+3fjMQjgkyX3Wt1x4ATmbx18kJ9ecYtiZKqBTHm1qChrXsWAoVQ69Ewg==",
+			"version": "15.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-15.0.1.tgz",
+			"integrity": "sha512-DcD4sJA1Q94dTcY9O6r5z9OaXM8V4Bbz948JSf12Sx6Uq1InDAZb3UQwMuZ+Mt2bAcun5GjkDQoOziaoImHB8w==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record": "^10.0.2",
 				"@natlibfi/marc-record-serializers": "^11.0.1",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": ">=24"
 			}
 		},
 		"node_modules/@natlibfi/melinda-marc-record-merge-reducers": {
@@ -910,6 +925,21 @@
 				"node": ">=24"
 			}
 		},
+		"node_modules/@natlibfi/melinda-marc-record-merge-reducers/node_modules/@natlibfi/melinda-commons": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.2.tgz",
+			"integrity": "sha512-Q8Lx4A1I17Hya2vwlSOgfCRC63PFA3+3fjMQjgkyX3Wt1x4ATmbx18kJ9ecYtiZKqBTHm1qChrXsWAoVQ69Ewg==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/sru-client": "^7.0.1",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
 		"node_modules/@natlibfi/melinda-record-match-validator": {
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-match-validator/-/melinda-record-match-validator-3.2.5.tgz",
@@ -922,6 +952,21 @@
 				"debug": "^4.4.3",
 				"isbn3": "^2.0.8",
 				"moment": "^2.30.1"
+			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
+		"node_modules/@natlibfi/melinda-record-match-validator/node_modules/@natlibfi/melinda-commons": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.2.tgz",
+			"integrity": "sha512-Q8Lx4A1I17Hya2vwlSOgfCRC63PFA3+3fjMQjgkyX3Wt1x4ATmbx18kJ9ecYtiZKqBTHm1qChrXsWAoVQ69Ewg==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/sru-client": "^7.0.1",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": ">=22"
@@ -950,9 +995,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-matching": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-6.0.0.tgz",
-			"integrity": "sha512-xHJg93OZ9F/CdoC3lKp4BwW1gWzK5tk28JZRpn9Z3cApuI1yooB1izZovT00cQ71xz4UcikvWrvF9URf7ej8fg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-matching/-/melinda-record-matching-6.0.2.tgz",
+			"integrity": "sha512-6t971gMLkqtb6YVEkL6fOdNUFD5kdW9O3Fhnri5WVhoIfTDCQwWt5d4/GdZO3ePZBcItGnGsxFGE2UIEvFODIQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
@@ -962,7 +1007,7 @@
 				"debug": "^4.4.3",
 				"isbn3": "^2.0.9",
 				"natural": "^8.1.1",
-				"yargs": "^18.0.0"
+				"yargs": "^18.1.0"
 			},
 			"bin": {
 				"melinda-record-matching": "dist/cli.js"
@@ -996,24 +1041,79 @@
 				"node": ">=24"
 			}
 		},
+		"node_modules/@natlibfi/melinda-record-matching/node_modules/@natlibfi/melinda-commons": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.2.tgz",
+			"integrity": "sha512-Q8Lx4A1I17Hya2vwlSOgfCRC63PFA3+3fjMQjgkyX3Wt1x4ATmbx18kJ9ecYtiZKqBTHm1qChrXsWAoVQ69Ewg==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/sru-client": "^7.0.1",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-5.0.7.tgz",
-			"integrity": "sha512-wzzGClyvhQgjUhEB2ShXZecjowWl9WVJW7UJW+qspZ/dPkyHvnRLBpkvMKXyjjfYd5bX8slFnLggeIQcGeOrOg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-6.0.0.tgz",
+			"integrity": "sha512-GWN9fx9cRbBbaSl/7X4s2c+wnfHu6TTVG4+uwXxyBNnUvWXCXNzJe/up5uZ/AGd2sy9dGDSNTshln2Q34KXKtA==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",
 				"@natlibfi/marc-record-serializers": "^11.0.3",
-				"@natlibfi/marc-record-validate": "^9.0.0",
-				"@natlibfi/marc-record-validators-melinda": "^12.0.15",
-				"@natlibfi/melinda-backend-commons": "^3.0.5",
-				"@natlibfi/melinda-commons": "^14.0.2",
+				"@natlibfi/marc-record-validate": "^9.0.1",
+				"@natlibfi/marc-record-validators-melinda": "^13.0.0",
+				"@natlibfi/melinda-backend-commons": "^3.0.6",
+				"@natlibfi/melinda-commons": "^15.0.1",
 				"amqplib": "^0.10.9",
 				"debug": "^4.4.3",
 				"http-status": "^2.1.0",
 				"moment": "^2.30.1",
 				"mongo-sanitize": "^1.1.0",
 				"mongodb": "^6.21.0"
+			},
+			"engines": {
+				"node": ">=24"
+			}
+		},
+		"node_modules/@natlibfi/melinda-rest-api-commons/node_modules/@natlibfi/marc-record-validators-melinda": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-13.0.0.tgz",
+			"integrity": "sha512-M6G6TdERFfhr9rP9wvKhmcgGSyzk+Wlsh7V+GEIft+DnX83oBKNztmSpWX7htocFjPk+HiutRuY7oJUrXxtDvg==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/iso9-1995": "^1.1.4",
+				"@natlibfi/issn-verify": "^2.0.3",
+				"@natlibfi/marc-record": "^10.0.2",
+				"@natlibfi/marc-record-serializers": "^11.0.3",
+				"@natlibfi/marc-record-validate": "^9.0.1",
+				"@natlibfi/melinda-commons": "^14.0.2",
+				"@natlibfi/sfs-4900": "^2.0.0",
+				"@natlibfi/sru-client": "^7.0.2",
+				"clone": "^2.1.2",
+				"debug": "^4.4.3",
+				"franc": "^6.2.0",
+				"isbn3": "^2.0.9",
+				"xml2js": "^0.6.2",
+				"xregexp": "^5.1.2"
+			},
+			"engines": {
+				"node": ">=24"
+			}
+		},
+		"node_modules/@natlibfi/melinda-rest-api-commons/node_modules/@natlibfi/marc-record-validators-melinda/node_modules/@natlibfi/melinda-commons": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.2.tgz",
+			"integrity": "sha512-Q8Lx4A1I17Hya2vwlSOgfCRC63PFA3+3fjMQjgkyX3Wt1x4ATmbx18kJ9ecYtiZKqBTHm1qChrXsWAoVQ69Ewg==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/sru-client": "^7.0.1",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": ">=22"
@@ -1143,6 +1243,12 @@
 				"color": "^5.0.2",
 				"text-hex": "1.0.x"
 			}
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"license": "MIT"
 		},
 		"node_modules/@types/esrecurse": {
 			"version": "4.3.1",
@@ -1330,16 +1436,16 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/bson": {
@@ -1463,9 +1569,9 @@
 			}
 		},
 		"node_modules/color-string/node_modules/color-name": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+			"integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20"
@@ -1484,9 +1590,9 @@
 			}
 		},
 		"node_modules/color/node_modules/color-name": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+			"integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20"
@@ -1740,9 +1846,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.7.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-			"integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+			"version": "10.8.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+			"integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -1752,7 +1858,7 @@
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
 				"@eslint/config-array": "^0.23.5",
-				"@eslint/config-helpers": "^0.6.0",
+				"@eslint/config-helpers": "^0.7.0",
 				"@eslint/core": "^1.2.1",
 				"@eslint/plugin-kit": "^0.7.2",
 				"@humanfs/node": "^0.16.6",
@@ -1776,7 +1882,7 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"minimatch": "^10.2.4",
+				"minimatch": "^10.2.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -2411,13 +2517,14 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "9.6.2",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.6.2.tgz",
-			"integrity": "sha512-7m8HntjkoRnwEmuPC0kdlwcZXJOQf4twumFj+PNzg/anqqZE2Er7hQslqyzy07mP3JcFjoTSgH5765PyqOXsxw==",
+			"version": "9.8.1",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.8.1.tgz",
+			"integrity": "sha512-1ncioLSBWeFSXIiKw6aR4YYFAhpvS7uSbPpkzq5ELSP9PEScGkbzFg6Q0mNuHighosmgZPYPsY4sSIXqkY3/hw==",
 			"license": "MIT",
 			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
 				"kareem": "3.3.0",
-				"mongodb": "~7.2",
+				"mongodb": "~7.5",
 				"mpath": "0.9.0",
 				"mquery": "6.0.0",
 				"ms": "2.1.3",
@@ -2441,23 +2548,23 @@
 			}
 		},
 		"node_modules/mongoose/node_modules/bson": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
-			"integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+			"integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/mongoose/node_modules/mongodb": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
-			"integrity": "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",
+			"integrity": "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@mongodb-js/saslprep": "^1.3.0",
+				"@mongodb-js/saslprep": "^1.4.11",
 				"bson": "^7.2.0",
-				"mongodb-connection-string-url": "^7.0.0"
+				"mongodb-connection-string-url": "^7.0.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -2467,7 +2574,7 @@
 				"@mongodb-js/zstd": "^7.0.0",
 				"gcp-metadata": "^7.0.1",
 				"kerberos": "^7.0.0",
-				"mongodb-client-encryption": ">=7.0.0 <7.1.0",
+				"mongodb-client-encryption": "^7.2.0",
 				"snappy": "^7.3.2",
 				"socks": "^2.8.6"
 			},
@@ -2496,9 +2603,9 @@
 			}
 		},
 		"node_modules/mongoose/node_modules/mongodb-connection-string-url": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
-			"integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.2.tgz",
+			"integrity": "sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/whatwg-url": "^13.0.0",
@@ -3355,15 +3462,15 @@
 			}
 		},
 		"node_modules/yargs": {
-			"version": "18.0.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^9.0.1",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
-				"string-width": "^7.2.0",
+				"string-width": "^8.2.1",
 				"y18n": "^5.0.5",
 				"yargs-parser": "^22.0.0"
 			},
@@ -3378,6 +3485,22 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:NatLibFi/melinda-rest-api-validator.git"
 	},
 	"license": "MIT",
-	"version": "5.0.0",
+	"version": "5.0.1-alpha.1",
 	"type": "module",
 	"main": "./dist/index.js",
 	"engines": {
@@ -37,11 +37,11 @@
 		"@natlibfi/marc-record-merge": "^8.0.1",
 		"@natlibfi/marc-record-serializers": "^11.0.3",
 		"@natlibfi/melinda-backend-commons": "^3.0.6",
-		"@natlibfi/melinda-commons": "^14.0.2",
+		"@natlibfi/melinda-commons": "^15.0.1",
 		"@natlibfi/melinda-marc-record-merge-reducers": "^4.0.0",
 		"@natlibfi/melinda-record-match-validator": "^3.2.5",
-		"@natlibfi/melinda-record-matching": "^6.0.0",
-		"@natlibfi/melinda-rest-api-commons": "^5.0.7",
+		"@natlibfi/melinda-record-matching": "^6.0.2",
+		"@natlibfi/melinda-rest-api-commons": "^6.0.0",
 		"@natlibfi/sru-client": "^7.0.1",
 		"debug": "^4.4.3",
 		"deep-eql": "^5.0.2",
@@ -53,7 +53,7 @@
 		"@natlibfi/fixura": "^4.0.1",
 		"cross-env": "^10.1.0",
 		"esbuild": "^0.28.1",
-		"eslint": "^10.7.0"
+		"eslint": "^10.8.0"
 	},
 	"overrides": {
 		"nanoid": "^3.3.8"


### PR DESCRIPTION
* Update matching v6.0.2 
Update https://github.com/NatLibFi/melinda-record-matching-js/releases/tag/v6.0.2
- Fix SRU search errors [MRA-904], [MRA-905], [MRA-907]
- Develop f028 candidate search [MRA-908], [MELKEHITYS-3523]

* Bump mongoose from 9.6.2 to 9.8.1 (#656) Bumps [mongoose](https://github.com/Automattic/mongoose) from 9.6.2 to 9.8.1.

* Update deps

* 5.0.1-alpha.1